### PR TITLE
build: dependencies version settings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,23 +19,23 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-web:3.0.1'
 
-    compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
-    testCompileOnly 'org.projectlombok:lombok'
-    testAnnotationProcessor 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok:1.18.24'
+    annotationProcessor 'org.projectlombok:lombok:1.18.24'
+    testCompileOnly 'org.projectlombok:lombok:1.18.24'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
 
     // database
-    runtimeOnly 'com.mysql:mysql-connector-j'
-    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j:8.0.31'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc:3.0.1'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.0.1'
 
     // flyway
-    implementation 'org.flywaydb:flyway-mysql'
+    implementation 'org.flywaydb:flyway-mysql:9.11.0'
 
     // test
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:3.0.1'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## Related Issue
#13 

## Description
`dependencies` 버전을 명시하였습니다.

`spring-boot-starter-web`: 3.0.1
`lombok`: 1.18.24
`mysql-connector-j`: 8.0.31
`jdbc`: 3.0.1
`jpa`: 3.0.1
`flyway-mysql`: 9.11.0
`spring-boot-test`: 3.0.1

## Screenshots (if appropriate):
