### PR TITLE
build: api documentation page deployment

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,0 +1,43 @@
+name: API Docs
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: API Docs
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Pages
+        uses: actions/configure-pages@v2
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: 17
+          distribution: 'zulu'
+          cache: 'gradle'
+      - name: Build
+        run: ./gradlew build
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: './src/main/resources/static/docs'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
## Related Issue

#24 

## Description

`GitHub Actions`를 활용하여 문서화 페이지를 빌드하고 배포합니다.

현재는 문서화 페이지를 빌드하기 위해 `./gradle build` 명령어를 이용하여 프로젝트 전체를 빌드해야 합니다.
결국 문서화 페이지를 배포하는 데까지의 시간을 지체시키고 있습니다.
가능하다면 문서화 페이지만 빌드하는 `Gradle task`를 생성하는 것이 좋을 것 같습니다.

## Screenshots (if appropriate):
