### PR TITLE
chore: disable naming convention check for class associated with OAuth

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -6,4 +6,5 @@
 
 <suppressions>
   <suppress message="Missing a Javadoc comment"/>
+  <suppress files=".*OAuth.*\.java" checks="AbbreviationAsWordInName"/>
 </suppressions>


### PR DESCRIPTION
## Related Issue
#29 
## Description
`OAuth` 관련 클래스의 네이밍 컨벤션 체크를 비활성화하여 `OAuth`에 대한 클래스는 1개 이상의 연속 대문자를 허용합니다.
## Screenshots (if appropriate):