### PR TITLE
chore: separating settings files based on profile

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,15 @@
+version: "3.8"
+
+services:
+  db:
+    container_name: dnd-db
+    image: mysql/mysql-server:8.0.31
+    ports:
+      - "3307:3306"
+    environment:
+      TZ: Asia/Seoul
+      MYSQL_DATABASE: dnd
+      MYSQL_ROOT_HOST: '%'
+      MYSQL_ROOT_PASSWORD: password
+    command:
+      - --character-set-server=utf8mb4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     image: mysql/mysql-server:8.0.31
     ports:
       - "3307:3306"
-    env_file:
-      - ./.env
     environment:
       TZ: Asia/Seoul
       MYSQL_DATABASE: $DB_NAME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - "3307:3306"
     environment:
       TZ: Asia/Seoul
-      MYSQL_DATABASE: $DB_NAME
+      MYSQL_DATABASE: ${DB_NAME}
       MYSQL_ROOT_HOST: '%'
-      MYSQL_ROOT_PASSWORD: $DB_PASSWORD
+      MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
     command:
       - --character-set-server=utf8mb4

--- a/src/main/java/com/dnd/wedding/WeddingApplication.java
+++ b/src/main/java/com/dnd/wedding/WeddingApplication.java
@@ -2,10 +2,8 @@ package com.dnd.wedding;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.PropertySource;
 
 @SpringBootApplication
-@PropertySource("classpath:/env.properties")
 public class WeddingApplication {
 
   public static void main(String[] args) {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3307/dnd?useSSL=false&characterEncoding=UTF-8&serverTimeZone=Asia/Seoul&allowPublicKeyRetrieval=true
+    username: root
+    password: password
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate.ddl-auto: validate
+    generate-ddl: false
+  flyway:
+    url: jdbc:mysql://localhost:3307/dnd?useSSL=false
+    user: root
+    password: password
+    enabled: true
+    baseline-on-migrate: true
+    locations: classpath:/db/migration

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,11 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate.ddl-auto: validate
+    generate-ddl: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,28 +1,3 @@
-spring:
-  # Database
-  datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-  
-  # JPA
-  jpa:
-    database: mysql
-    database-platform: org.hibernate.dialect.MySQL8Dialect
-    hibernate.ddl-auto: validate
-    generate-ddl: false
-
-  # flyway
-  flyway:
-    enabled: true
-    baseline-on-migrate: true
-    locations: classpath:/db/migration
-    url: ${FLYWAY_URL}
-    user: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-
-# log
 logging:
   level:
     org:


### PR DESCRIPTION
## Related Issue

#34 

## Description

로컬환경과 배포환경에 따른 설정파일을 분리하였습니다.
앞으로 설정파일은 다음과 같이 사용해주시면 됩니다.

- application.yml
  - 모든 환경에서 사용되는 공통된 설정
- application-local.yml
  - 로컬 환경에서 필요한 설정
- application-prod.yml
  - 배포 환경에서 필요한 설정
  - 모든 `credential` 정보들은 `환경변수`로 지정

이와 동시에 docker-compose도 로컬과 배포환경을 분리하였습니다.

- docker-compose.local.yml
  - 로컬에서 사용하는 컴포즈 파일
- docker-compose.yml
  - 배포 환경에서 사용하는 컴포즈 파일

> **Note** 모든 로컬에서 필요한 테스트용 설정은 노출되어도 무방합니다.

## Screenshots (if appropriate):

> **Warning** 로컬 환경에서는 다음과 같은 설정을 진행해주셔야 합니다.

![스크린샷 2023-01-26 오전 2 25 22](https://user-images.githubusercontent.com/44942700/214636607-edd19337-6157-4d52-91c4-8aea46f9d08a.png)

구성편집 클릭

![스크린샷 2023-01-26 오전 2 25 45](https://user-images.githubusercontent.com/44942700/214636726-35c5e4ef-29c7-424a-8d52-06157813228d.png)

프로파일에 local이라고 입력
