### PR TITLE
chore: set in memory db for test environment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j:8.0.31'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc:3.0.1'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa:3.0.1'
+    runtimeOnly 'com.h2database:h2:2.1.214'
 
     // flyway
     implementation 'org.flywaydb:flyway-mysql:9.11.0'

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  flyway:
+    enabled: false


### PR DESCRIPTION
## Related Issue

#36 

## Description

테스트 코드 동작시 데이터베이스를 H2 인메모리를 사용하도록 설정합니다.
스프링 상에서 @DataJpaTest 어노테이션을 사용해 레포지토리에 대한 테스트를 실행하면 기본적으로 H2를 사용하므로 설정 파일 상에 별도로 명시하지 않았습니다.

## Screenshots (if appropriate):
