### PR TITLE
build: change github action workflow trigger

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
 jobs:
   sonarcloud:


### PR DESCRIPTION
## Related Issue

#40 

## Description

깃헙 액션의 트리거를 수정하여 문서가 프로덕션에 적용된 API만을 제공하도록 합니다.
추가로 SonarCloud가 develop 브랜치 이벤트에도 동작하도록 설정합니다.

## Screenshots (if appropriate):
