### PR TITLE
feat: renew authentication token

### DIFF
--- a/src/main/java/com/dnd/wedding/domain/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/JwtTokenProvider.java
@@ -96,7 +96,7 @@ public class JwtTokenProvider {
     CustomUserDetails user = (CustomUserDetails) authentication.getPrincipal();
 
     refreshTokenRedisRepository.save(RefreshToken.builder()
-        .email(user.getEmail())
+        .id(user.getId())
         .token(refreshToken)
         .expiredTime(REFRESH_TOKEN_EXPIRE_LENGTH)
         .build());

--- a/src/main/java/com/dnd/wedding/domain/jwt/RefreshToken.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/RefreshToken.java
@@ -12,11 +12,11 @@ import org.springframework.data.redis.core.TimeToLive;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@RedisHash(value = "email")
+@RedisHash(value = "id")
 public class RefreshToken {
 
   @Id
-  private String email;
+  private Long id;
   private String token;
 
   @TimeToLive

--- a/src/main/java/com/dnd/wedding/domain/jwt/controller/JwtController.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/controller/JwtController.java
@@ -5,6 +5,7 @@ import io.lettuce.core.dynamic.annotation.Param;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +21,11 @@ public class JwtController {
   @GetMapping("/refresh")
   public ResponseEntity refreshToken(HttpServletRequest request, HttpServletResponse response,
       @Param("accessToken") String accessToken) {
-    return ResponseEntity.ok().body(jwtService.refreshToken(request, response, accessToken));
+    String newToken = jwtService.refreshToken(request, response, accessToken);
+
+    if (newToken != null) {
+      return ResponseEntity.ok().body(newToken);
+    }
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Failed renew access token");
   }
 }

--- a/src/main/java/com/dnd/wedding/domain/jwt/controller/JwtController.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/controller/JwtController.java
@@ -1,0 +1,25 @@
+package com.dnd.wedding.domain.jwt.controller;
+
+import com.dnd.wedding.domain.jwt.service.JwtService;
+import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/jwt")
+public class JwtController {
+
+  private final JwtService jwtService;
+
+  @GetMapping("/refresh")
+  public ResponseEntity refreshToken(HttpServletRequest request, HttpServletResponse response,
+      @Param("accessToken") String accessToken) {
+    return ResponseEntity.ok().body(jwtService.refreshToken(request, response, accessToken));
+  }
+}

--- a/src/main/java/com/dnd/wedding/domain/jwt/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/repository/RefreshTokenRedisRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, String> {
+public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, Long> {
 
 }

--- a/src/main/java/com/dnd/wedding/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/service/JwtService.java
@@ -9,7 +9,6 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -17,7 +16,6 @@ import org.springframework.stereotype.Service;
 
 @Log4j2
 @Service
-@RequiredArgsConstructor
 public class JwtService {
 
   @Value("${app.auth.token.refresh-cookie-key}")
@@ -25,6 +23,13 @@ public class JwtService {
 
   private final RefreshTokenRedisRepository refreshTokenRedisRepository;
   private final JwtTokenProvider tokenProvider;
+
+  public JwtService(@Value("${app.auth.token.refresh-cookie-key}") String cookieKey,
+      RefreshTokenRedisRepository refreshTokenRedisRepository, JwtTokenProvider tokenProvider) {
+    this.cookieKey = cookieKey;
+    this.refreshTokenRedisRepository = refreshTokenRedisRepository;
+    this.tokenProvider = tokenProvider;
+  }
 
   public String refreshToken(HttpServletRequest request, HttpServletResponse response,
       String oldAccessToken) {

--- a/src/main/java/com/dnd/wedding/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/service/JwtService.java
@@ -21,7 +21,7 @@ import org.springframework.stereotype.Service;
 public class JwtService {
 
   @Value("${app.auth.token.refresh-cookie-key}")
-  private String cookieKey;
+  private final String cookieKey;
 
   private final RefreshTokenRedisRepository refreshTokenRedisRepository;
   private final JwtTokenProvider tokenProvider;

--- a/src/main/java/com/dnd/wedding/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/service/JwtService.java
@@ -31,8 +31,9 @@ public class JwtService {
     String oldRefreshToken = CookieUtil.getCookie(request, cookieKey)
         .map(Cookie::getValue).orElseThrow(() -> new RuntimeException("No Refresh Token Cookie"));
 
-    if (!tokenProvider.validateToken(oldRefreshToken)) {
+    if (Boolean.FALSE.equals(tokenProvider.validateToken(oldRefreshToken))) {
       log.info("Not Validated Refresh Token.");
+      return null;
     }
 
     Authentication authentication = tokenProvider.getAuthentication(oldAccessToken);
@@ -43,12 +44,14 @@ public class JwtService {
 
     if (savedToken.isEmpty()) {
       log.info("Not Existed Refresh Token.");
+      return null;
     } else {
       if (!(savedToken.get().getToken().equals(oldRefreshToken))) {
         log.info("Not Validated Refresh Token.");
+        return null;
       }
     }
-    
+
     String accessToken = tokenProvider.createAccessToken(authentication);
     tokenProvider.addRefreshToken(authentication, response);
 

--- a/src/main/java/com/dnd/wedding/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/service/JwtService.java
@@ -1,0 +1,57 @@
+package com.dnd.wedding.domain.jwt.service;
+
+import com.dnd.wedding.domain.jwt.JwtTokenProvider;
+import com.dnd.wedding.domain.jwt.RefreshToken;
+import com.dnd.wedding.domain.jwt.repository.RefreshTokenRedisRepository;
+import com.dnd.wedding.domain.oauth.CustomUserDetails;
+import com.dnd.wedding.global.config.util.CookieUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+  @Value("${app.auth.token.refresh-cookie-key}")
+  private String cookieKey;
+
+  private final RefreshTokenRedisRepository refreshTokenRedisRepository;
+  private final JwtTokenProvider tokenProvider;
+
+  public String refreshToken(HttpServletRequest request, HttpServletResponse response,
+      String oldAccessToken) {
+    String oldRefreshToken = CookieUtil.getCookie(request, cookieKey)
+        .map(Cookie::getValue).orElseThrow(() -> new RuntimeException("No Refresh Token Cookie"));
+
+    if (!tokenProvider.validateToken(oldRefreshToken)) {
+      log.info("Not Validated Refresh Token.");
+    }
+
+    Authentication authentication = tokenProvider.getAuthentication(oldAccessToken);
+    CustomUserDetails user = (CustomUserDetails) authentication.getPrincipal();
+
+    Long id = user.getId();
+    Optional<RefreshToken> savedToken = refreshTokenRedisRepository.findById(id);
+
+    if (savedToken.isEmpty()) {
+      log.info("Not Existed Refresh Token.");
+    } else {
+      if (!(savedToken.get().getToken().equals(oldRefreshToken))) {
+        log.info("Not Validated Refresh Token.");
+      }
+    }
+    
+    String accessToken = tokenProvider.createAccessToken(authentication);
+    tokenProvider.addRefreshToken(authentication, response);
+
+    return accessToken;
+  }
+}

--- a/src/main/java/com/dnd/wedding/global/config/RedisConfig.java
+++ b/src/main/java/com/dnd/wedding/global/config/RedisConfig.java
@@ -32,8 +32,8 @@ public class RedisConfig {
   }
 
   @Bean
-  public RedisTemplate<String, String> redisTemplate() {
-    RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+  public RedisTemplate<Long, String> redisTemplate() {
+    RedisTemplate<Long, String> redisTemplate = new RedisTemplate<>();
 
     redisTemplate.setKeySerializer(new StringRedisSerializer());
     redisTemplate.setValueSerializer(new StringRedisSerializer());

--- a/src/main/java/com/dnd/wedding/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/wedding/global/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
 
     http.authorizeHttpRequests()
         .requestMatchers(HttpMethod.GET, "/oauth2/**").permitAll()
+        .requestMatchers("/api/v1/jwt/**").permitAll()
         .anyRequest().authenticated();
 
     http

--- a/src/test/java/com/dnd/wedding/domain/jwt/controller/JwtControllerTest.java
+++ b/src/test/java/com/dnd/wedding/domain/jwt/controller/JwtControllerTest.java
@@ -1,0 +1,44 @@
+package com.dnd.wedding.domain.jwt.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.dnd.wedding.domain.jwt.service.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class JwtControllerTest {
+
+  JwtController jwtController;
+  JwtService jwtService;
+  MockHttpServletRequest request;
+  MockHttpServletResponse response;
+
+  @BeforeEach
+  void init() {
+    jwtService = mock(JwtService.class);
+    jwtController = new JwtController(jwtService);
+    request = new MockHttpServletRequest();
+    response = new MockHttpServletResponse();
+  }
+
+  @Test
+  @DisplayName("access token 갱신 성공 시 새로 발급한 token을 전달한다.")
+  void successRenewAccessToken() {
+    // given
+    given(jwtService.refreshToken(request, response, "accessToken")).willReturn("token");
+
+    // when
+    ResponseEntity responseEntity = jwtController.refreshToken(request, response, "accessToken");
+
+    // then
+    assertEquals("token", responseEntity.getBody());
+    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+  }
+}

--- a/src/test/java/com/dnd/wedding/domain/jwt/controller/JwtControllerTest.java
+++ b/src/test/java/com/dnd/wedding/domain/jwt/controller/JwtControllerTest.java
@@ -41,4 +41,17 @@ class JwtControllerTest {
     assertEquals("token", responseEntity.getBody());
     assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
   }
+
+  @Test
+  @DisplayName("access token 갱신 실패 시 401 코드가 전달된다.")
+  void failRenewAccessToken() {
+    // given
+    given(jwtService.refreshToken(request, response, "accessToken")).willReturn(null);
+
+    // when
+    ResponseEntity responseEntity = jwtController.refreshToken(request, response, "accessToken");
+
+    // then
+    assertEquals(HttpStatus.UNAUTHORIZED, responseEntity.getStatusCode());
+  }
 }

--- a/src/test/java/com/dnd/wedding/domain/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/dnd/wedding/domain/jwt/service/JwtServiceTest.java
@@ -1,0 +1,128 @@
+package com.dnd.wedding.domain.jwt.service;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.dnd.wedding.domain.jwt.JwtTokenProvider;
+import com.dnd.wedding.domain.jwt.RefreshToken;
+import com.dnd.wedding.domain.jwt.repository.RefreshTokenRedisRepository;
+import com.dnd.wedding.domain.member.Role;
+import com.dnd.wedding.domain.oauth.CustomUserDetails;
+import com.dnd.wedding.domain.oauth.OAuth2Provider;
+import jakarta.servlet.http.Cookie;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+class JwtServiceTest {
+
+  private static final Collection<? extends GrantedAuthority> authority = Collections.singletonList(
+      new SimpleGrantedAuthority("ROLE_USER"));
+
+  private final String cookieKey = "testCookieKey";
+  private final String oldRefreshToken = "testRefreshToken";
+  private final String oldAccessToken = "testAccessToken";
+  private CustomUserDetails customUserDetails = new CustomUserDetails(1L, "test@test.com",
+      OAuth2Provider.GOOGLE, Role.USER, authority);
+  private RefreshTokenRedisRepository refreshTokenRedisRepository;
+  private JwtTokenProvider tokenProvider;
+  private JwtService jwtService;
+  MockHttpServletResponse response;
+  MockHttpServletRequest request;
+  Authentication authentication;
+
+  @BeforeEach
+  void init() {
+    this.refreshTokenRedisRepository = mock(RefreshTokenRedisRepository.class);
+    this.tokenProvider = mock(JwtTokenProvider.class);
+    this.authentication = mock(Authentication.class);
+    this.jwtService = new JwtService(cookieKey, refreshTokenRedisRepository, tokenProvider);
+    this.request = new MockHttpServletRequest();
+    this.response = new MockHttpServletResponse();
+  }
+
+  @Test
+  @DisplayName("쿠키에 refresh token이 없는 경우 에러가 발생한다.")
+  void throwException() {
+    assertThrows(RuntimeException.class, () -> jwtService.refreshToken(request, response, "token"));
+  }
+
+  @Test
+  @DisplayName("accessToken 재발급 성공")
+  void suceessRenewToken() {
+    Cookie cookie = new Cookie(cookieKey, oldRefreshToken);
+    request.setCookies(cookie);
+
+    RefreshToken refreshToken = RefreshToken.builder()
+        .id(1L)
+        .token(oldRefreshToken)
+        .build();
+    when(tokenProvider.validateToken(oldRefreshToken)).thenReturn(true);
+    when(tokenProvider.getAuthentication(oldAccessToken)).thenReturn(authentication);
+    when(authentication.getPrincipal()).thenReturn(customUserDetails);
+    when(refreshTokenRedisRepository.findById(1L)).thenReturn(Optional.of(refreshToken));
+
+    jwtService.refreshToken(request, response, oldAccessToken);
+    verify(tokenProvider).createAccessToken(authentication);
+    verify(tokenProvider).addRefreshToken(authentication, response);
+  }
+
+  @Test
+  @DisplayName("refresh token이 유효하지 않은 경우 null을 반환한다.")
+  void failRenewTokenByInvalidRefreshToken() {
+    Cookie cookie = new Cookie(cookieKey, oldRefreshToken);
+    request.setCookies(cookie);
+
+    String token = jwtService.refreshToken(request, response, oldAccessToken);
+
+    assertNull(token);
+  }
+
+  @Test
+  @DisplayName("저장된 refresh token이 없는 경우 null을 반환한다.")
+  void failRenewTokenByNotSavedRefreshToken() {
+    Cookie cookie = new Cookie(cookieKey, oldRefreshToken);
+    request.setCookies(cookie);
+
+    when(tokenProvider.validateToken(oldRefreshToken)).thenReturn(true);
+    when(tokenProvider.getAuthentication(oldAccessToken)).thenReturn(authentication);
+    when(authentication.getPrincipal()).thenReturn(customUserDetails);
+
+    String token = jwtService.refreshToken(request, response, oldAccessToken);
+
+    assertNull(token);
+  }
+
+  @Test
+  @DisplayName("쿠키의 refresh token이 저장된 refresh token과 일치하지 않는 경우 null을 반환한다.")
+  void failRenewTokenByDifferentRefreshToken() {
+    Cookie cookie = new Cookie(cookieKey, oldRefreshToken);
+    request.setCookies(cookie);
+
+    RefreshToken refreshToken = RefreshToken.builder()
+        .id(1L)
+        .token("test")
+        .build();
+
+    when(tokenProvider.validateToken(oldRefreshToken)).thenReturn(true);
+    when(tokenProvider.getAuthentication(oldAccessToken)).thenReturn(authentication);
+    when(authentication.getPrincipal()).thenReturn(customUserDetails);
+    when(refreshTokenRedisRepository.findById(1L)).thenReturn(Optional.of(refreshToken));
+
+    String token = jwtService.refreshToken(request, response, oldAccessToken);
+
+    assertNull(token);
+  }
+}


### PR DESCRIPTION
## Related Issue
#27 

## Description
`refresh token`을 사용해 만료된 `access token`을 갱신하는 로직을 추가하였습니다.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/89819254/216628632-c4fd1b07-d8de-4d5f-a4d7-327c4462f759.png)
