### PR TITLE
fix: change cookie deserialize function from CookieUtil

### DIFF
--- a/src/main/java/com/dnd/wedding/global/config/util/CookieUtil.java
+++ b/src/main/java/com/dnd/wedding/global/config/util/CookieUtil.java
@@ -3,6 +3,10 @@ package com.dnd.wedding.global.config.util;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectInputStream;
 import java.util.Base64;
 import java.util.Optional;
 import org.springframework.util.SerializationUtils;
@@ -56,7 +60,12 @@ public class CookieUtil {
   }
 
   public static <T> T deserialize(Cookie cookie, Class<T> cls) {
-    return cls.cast(SerializationUtils.deserialize(
-        Base64.getUrlDecoder().decode(cookie.getValue())));
+    try (ByteArrayInputStream bis = new ByteArrayInputStream(
+        Base64.getUrlDecoder().decode(cookie.getValue()));
+        ObjectInput in = new ObjectInputStream(bis)) {
+      return cls.cast(in.readObject());
+    } catch (IOException | ClassNotFoundException e) {
+      throw new IllegalArgumentException("Failed to deserialize object", e);
+    }
   }
 }


### PR DESCRIPTION
## Related Issue
#45 

## Description
기존에 작성했던 `SerializationUtils.deserialize` 함수가 **deprecated**되어  `java.io`의 `ObjectInputStream`을 사용하는 방법으로 변경하였습니다.

[참고 글](https://steady-coding.tistory.com/576)
## Screenshots (if appropriate):
