### PR TITLE
feat: change csrf setting to disabled

### DIFF
--- a/src/main/java/com/dnd/wedding/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/wedding/global/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.cors()
         .and()
+        .csrf().disable()
         .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
     http.authorizeHttpRequests()


### PR DESCRIPTION
## Related Issue
None
## Description
**CSRF** 설정으로 인해 Get 요청을 제외한 나머지 HTTP 요청에서 모두 401 상태 코드를 반환합니다.
**REST API**는 **CSRF**와 관련이 없으므로 `SecurityConfig`에 `csrf().disable()`을 추가하였습니다.
## Screenshots (if appropriate):
