### PR TITLE
fix: add authorizationRequestRepository setting to SecurityConfig

### DIFF
--- a/src/main/java/com/dnd/wedding/domain/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/dnd/wedding/domain/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -61,7 +61,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     tokenProvider.addRefreshToken(authentication, response);
 
     return UriComponentsBuilder.fromUriString(targetUrl)
-        .queryParam("accessToken", accessToken)
+        .queryParam("code", accessToken)
         .build().toUriString();
   }
 

--- a/src/main/java/com/dnd/wedding/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/wedding/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.dnd.wedding.global.config;
 import com.dnd.wedding.domain.jwt.JwtAuthenticationEntryPoint;
 import com.dnd.wedding.domain.jwt.JwtAuthenticationFilter;
 import com.dnd.wedding.domain.jwt.handler.JwtAccessDeniedHandler;
+import com.dnd.wedding.domain.jwt.repository.CookieAuthorizationRequestRepository;
 import com.dnd.wedding.domain.oauth.handler.OAuth2AuthenticationFailureHandler;
 import com.dnd.wedding.domain.oauth.handler.OAuth2AuthenticationSuccessHandler;
 import com.dnd.wedding.domain.oauth.service.CustomOAuth2UserService;
@@ -25,6 +26,7 @@ public class SecurityConfig {
   private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
   private final OAuth2AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler;
   private final OAuth2AuthenticationFailureHandler oauth2AuthenticationFailureHandler;
+  private final CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -44,6 +46,7 @@ public class SecurityConfig {
         .oauth2Login()
         .authorizationEndpoint()
         .baseUri("/oauth2/authorization")
+        .authorizationRequestRepository(cookieAuthorizationRequestRepository)
         .and()
         .userInfoEndpoint()
         .userService(customOauth2UserService)


### PR DESCRIPTION
## Related Issue
None
## Description
redirect uri 설정을 위해 `SecurityConfig`의 `authorizationRequestRepository`로 `CookieAuthorizationRequestRepository`를 설정해주었습니다.
Google 로그인 요청 시 url의 파라미터로 **redirect_uri**를 추가해주시면 됩니다.

예시)
`http://localhost:8080/oauth2/authorization/google?redirect_uri=http://localhost:8080/oauth2/redirect`
## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/89819254/218250215-1dbe872d-1b12-410c-a9d3-eb3d32a48fac.png)
