### PR TITLE
feat: add exception handler used ControllerAdvice

### DIFF
--- a/src/main/java/com/dnd/wedding/domain/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/dnd/wedding/domain/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -5,8 +5,8 @@ import static com.dnd.wedding.domain.jwt.repository.CookieAuthorizationRequestRe
 
 import com.dnd.wedding.domain.jwt.JwtTokenProvider;
 import com.dnd.wedding.domain.jwt.repository.CookieAuthorizationRequestRepository;
-import com.dnd.wedding.domain.oauth.exception.BadRequestException;
 import com.dnd.wedding.global.config.util.CookieUtil;
+import com.dnd.wedding.global.exception.BadRequestException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/dnd/wedding/global/exception/BadRequestException.java
+++ b/src/main/java/com/dnd/wedding/global/exception/BadRequestException.java
@@ -1,4 +1,4 @@
-package com.dnd.wedding.domain.oauth.exception;
+package com.dnd.wedding.global.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -8,9 +8,5 @@ public class BadRequestException extends RuntimeException {
 
   public BadRequestException(String message) {
     super(message);
-  }
-
-  public BadRequestException(String message, Throwable cause) {
-    super(message, cause);
   }
 }

--- a/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
@@ -14,7 +14,6 @@ public class ControllerExceptionHandler {
   public ResponseEntity<ErrorMessage> notFoundException(NotFoundException ex) {
     ErrorMessage message = new ErrorMessage(
         HttpStatus.NOT_FOUND.value(),
-        new Date(),
         ex.getMessage());
 
     return new ResponseEntity<>(message, HttpStatus.NOT_FOUND);

--- a/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
@@ -1,6 +1,6 @@
 package com.dnd.wedding.global.exception;
 
-import java.util.Date;
+import com.dnd.wedding.domain.oauth.exception.BadRequestException;
 import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,5 +17,42 @@ public class ControllerExceptionHandler {
         ex.getMessage());
 
     return new ResponseEntity<>(message, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(BadRequestException.class)
+  public ResponseEntity<ErrorMessage> badRequestException(BadRequestException ex) {
+    ErrorMessage message = new ErrorMessage(
+        HttpStatus.BAD_REQUEST.value(),
+        ex.getMessage());
+
+    return new ResponseEntity<>(message, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(UnauthorizedException.class)
+  public ResponseEntity<ErrorMessage> unauthorizedUserException(UnauthorizedException ex) {
+    ErrorMessage message = new ErrorMessage(
+        HttpStatus.UNAUTHORIZED.value(),
+        ex.getMessage());
+
+    return new ResponseEntity<>(message, HttpStatus.UNAUTHORIZED);
+  }
+
+  @ExceptionHandler(ForbiddenException.class)
+  public ResponseEntity<ErrorMessage> forbiddenRequestException(ForbiddenException ex) {
+    ErrorMessage message = new ErrorMessage(
+        HttpStatus.FORBIDDEN.value(),
+        ex.getMessage());
+
+    return new ResponseEntity<>(message, HttpStatus.FORBIDDEN);
+  }
+
+  @ExceptionHandler(InternalServerErrorException.class)
+  public ResponseEntity<ErrorMessage> internalServerErrorException(
+      InternalServerErrorException ex) {
+    ErrorMessage message = new ErrorMessage(
+        HttpStatus.INTERNAL_SERVER_ERROR.value(),
+        ex.getMessage());
+
+    return new ResponseEntity<>(message, HttpStatus.INTERNAL_SERVER_ERROR);
   }
 }

--- a/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.dnd.wedding.global.exception;
 
-import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;

--- a/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.dnd.wedding.global.exception;
+
+import java.util.Date;
+import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class ControllerExceptionHandler {
+
+  @ExceptionHandler(NotFoundException.class)
+  public ResponseEntity<ErrorMessage> notFoundException(NotFoundException ex) {
+    ErrorMessage message = new ErrorMessage(
+        HttpStatus.NOT_FOUND.value(),
+        new Date(),
+        ex.getMessage());
+
+    return new ResponseEntity<>(message, HttpStatus.NOT_FOUND);
+  }
+}

--- a/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.dnd.wedding.global.exception;
 
-import com.dnd.wedding.domain.oauth.exception.BadRequestException;
 import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/dnd/wedding/global/exception/ErrorMessage.java
+++ b/src/main/java/com/dnd/wedding/global/exception/ErrorMessage.java
@@ -5,11 +5,11 @@ import lombok.Getter;
 @Getter
 public class ErrorMessage {
 
-  private int statusCode;
+  private int status;
   private String message;
 
-  public ErrorMessage(int statusCode, String message) {
-    this.statusCode = statusCode;
+  public ErrorMessage(int status, String message) {
+    this.status = status;
     this.message = message;
   }
 }

--- a/src/main/java/com/dnd/wedding/global/exception/ErrorMessage.java
+++ b/src/main/java/com/dnd/wedding/global/exception/ErrorMessage.java
@@ -1,0 +1,18 @@
+package com.dnd.wedding.global.exception;
+
+import java.util.Date;
+import lombok.Getter;
+
+@Getter
+public class ErrorMessage {
+
+  private int statusCode;
+  private Date timestamp;
+  private String message;
+
+  public ErrorMessage(int statusCode, Date timestamp, String message) {
+    this.statusCode = statusCode;
+    this.timestamp = timestamp;
+    this.message = message;
+  }
+}

--- a/src/main/java/com/dnd/wedding/global/exception/ErrorMessage.java
+++ b/src/main/java/com/dnd/wedding/global/exception/ErrorMessage.java
@@ -1,18 +1,15 @@
 package com.dnd.wedding.global.exception;
 
-import java.util.Date;
 import lombok.Getter;
 
 @Getter
 public class ErrorMessage {
 
   private int statusCode;
-  private Date timestamp;
   private String message;
 
-  public ErrorMessage(int statusCode, Date timestamp, String message) {
+  public ErrorMessage(int statusCode, String message) {
     this.statusCode = statusCode;
-    this.timestamp = timestamp;
     this.message = message;
   }
 }

--- a/src/main/java/com/dnd/wedding/global/exception/ForbiddenException.java
+++ b/src/main/java/com/dnd/wedding/global/exception/ForbiddenException.java
@@ -1,0 +1,12 @@
+package com.dnd.wedding.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.FORBIDDEN, reason = "Forbidden")
+public class ForbiddenException extends RuntimeException {
+
+  public ForbiddenException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/dnd/wedding/global/exception/InternalServerErrorException.java
+++ b/src/main/java/com/dnd/wedding/global/exception/InternalServerErrorException.java
@@ -1,0 +1,12 @@
+package com.dnd.wedding.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR, reason = "InternalServerError")
+public class InternalServerErrorException extends RuntimeException {
+
+  public InternalServerErrorException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/dnd/wedding/global/exception/NotFoundException.java
+++ b/src/main/java/com/dnd/wedding/global/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package com.dnd.wedding.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Not Found")
+public class NotFoundException extends RuntimeException {
+
+  public NotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/dnd/wedding/global/exception/UnauthorizedException.java
+++ b/src/main/java/com/dnd/wedding/global/exception/UnauthorizedException.java
@@ -1,0 +1,12 @@
+package com.dnd.wedding.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.UNAUTHORIZED, reason = "Unauthorized")
+public class UnauthorizedException extends RuntimeException {
+
+  public UnauthorizedException(String message) {
+    super(message);
+  }
+}

--- a/src/test/java/com/dnd/wedding/domain/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/dnd/wedding/domain/jwt/JwtTokenProviderTest.java
@@ -91,7 +91,7 @@ class JwtTokenProviderTest {
     given(authentication.getPrincipal()).willReturn(customUserDetailsObject);
     given(refreshTokenRedisRepository.save(new RefreshToken())).willReturn(new RefreshToken());
 
-    ResponseCookie cookie = ResponseCookie.from("cookie", refreshToken2)
+    ResponseCookie cookie1 = ResponseCookie.from("cookie", refreshToken2)
         .httpOnly(true)
         .secure(true)
         .sameSite("dnd")
@@ -101,7 +101,7 @@ class JwtTokenProviderTest {
 
     jwtTokenProvider.addRefreshToken(authentication, response);
 
-    verify(response).addHeader("Set-Cookie", cookie.toString());
+    verify(response).addHeader("Set-Cookie", cookie1.toString());
   }
 
   @Test

--- a/src/test/java/com/dnd/wedding/global/exception/ControllerExceptionHandlerTest.java
+++ b/src/test/java/com/dnd/wedding/global/exception/ControllerExceptionHandlerTest.java
@@ -3,7 +3,6 @@ package com.dnd.wedding.global.exception;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import com.dnd.wedding.domain.oauth.exception.BadRequestException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/dnd/wedding/global/exception/ControllerExceptionHandlerTest.java
+++ b/src/test/java/com/dnd/wedding/global/exception/ControllerExceptionHandlerTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -22,11 +21,13 @@ class ControllerExceptionHandlerTest {
   @Test
   @DisplayName("NotFoundException 발생 테스트")
   void notFoundExceptionTest() {
-    NotFoundException ex = new NotFoundException();
+    String message = "Not Found";
+    NotFoundException ex = new NotFoundException(message);
     ResponseEntity<ErrorMessage> error = controllerExceptionHandler.notFoundException(ex);
 
     assertNotNull(error);
     assertEquals(HttpStatus.NOT_FOUND, error.getStatusCode());
+    assertEquals(message, error.getBody().getMessage());
   }
 
   @Test

--- a/src/test/java/com/dnd/wedding/global/exception/ControllerExceptionHandlerTest.java
+++ b/src/test/java/com/dnd/wedding/global/exception/ControllerExceptionHandlerTest.java
@@ -1,0 +1,81 @@
+package com.dnd.wedding.global.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.dnd.wedding.domain.oauth.exception.BadRequestException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+class ControllerExceptionHandlerTest {
+
+  private ControllerExceptionHandler controllerExceptionHandler;
+
+  @BeforeEach
+  public void init() throws Exception {
+    controllerExceptionHandler = new ControllerExceptionHandler();
+  }
+
+  @Test
+  @DisplayName("NotFoundException 발생 테스트")
+  void notFoundExceptionTest() {
+    NotFoundException ex = new NotFoundException();
+    ResponseEntity<ErrorMessage> error = controllerExceptionHandler.notFoundException(ex);
+
+    assertNotNull(error);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatusCode());
+  }
+
+  @Test
+  @DisplayName("BadRequestException 발생 테스트")
+  void badRequestExceptionTest() {
+    String message = "Bad request";
+    BadRequestException ex = new BadRequestException(message);
+    ResponseEntity<ErrorMessage> error = controllerExceptionHandler.badRequestException(ex);
+
+    assertNotNull(error);
+    assertEquals(HttpStatus.BAD_REQUEST, error.getStatusCode());
+    assertEquals(message, error.getBody().getMessage());
+  }
+
+  @Test
+  @DisplayName("UnauthorizedException 발생 테스트")
+  void unauthorizedUserExceptionTest() {
+    String message = "Unauthorized user";
+    UnauthorizedException ex = new UnauthorizedException(message);
+    ResponseEntity<ErrorMessage> error = controllerExceptionHandler.unauthorizedUserException(ex);
+
+    assertNotNull(error);
+    assertEquals(HttpStatus.UNAUTHORIZED, error.getStatusCode());
+    assertEquals(message, error.getBody().getMessage());
+  }
+
+  @Test
+  @DisplayName("ForbiddenException 발생 테스트")
+  void forbiddenRequestExceptionTest() {
+    String message = "Forbidden";
+    ForbiddenException ex = new ForbiddenException(message);
+    ResponseEntity<ErrorMessage> error = controllerExceptionHandler.forbiddenRequestException(ex);
+
+    assertNotNull(error);
+    assertEquals(HttpStatus.FORBIDDEN, error.getStatusCode());
+    assertEquals(message, error.getBody().getMessage());
+  }
+
+  @Test
+  @DisplayName("InternalServerErrorException 발생 테스트")
+  void internalServerErrorExceptionTest() {
+    String message = "Internal Server Error";
+    InternalServerErrorException ex = new InternalServerErrorException(message);
+    ResponseEntity<ErrorMessage> error = controllerExceptionHandler.internalServerErrorException(
+        ex);
+
+    assertNotNull(error);
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, error.getStatusCode());
+    assertEquals(message, error.getBody().getMessage());
+  }
+}


### PR DESCRIPTION
## Related Issue
None
## Description
전역적인 예외처리를 위해 `ErrorMessage` 포맷을 정의하고 `ControllerAdvice`를 사용한 `ControllerExceptionHandler`를 추가하였습니다. `@ExceptionHandler` 어노테이션을 통해 예외에 대한 처리를 추가하여 사용할 수 있습니다.

이는 Controller 전역에서 사용 가능하며 이외의 Service 로직에서는 동작하지 않습니다.

> 잘못된 요청: BadRequestException
> 인증되지 않은 사용자: UnauthorizedException
> 접근 권한 없음: ForbiddenException
> 존재하지 않는 리소스: NotFoundException
> 서버 내부 오류: InternalServerErrorException

## Screenshots (if appropriate):
