### PR TITLE
build: add validation dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.0.0'
     implementation 'org.springframework.boot:spring-boot-starter-security:3.0.1'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client:3.0.1'
+    implementation 'org.springframework.boot:spring-boot-starter-validation:3.0.2'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test:3.0.1'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:3.0.0'


### PR DESCRIPTION
## Related Issue
None

## Description
DTO 및 데이터에 대한 validation 어노테이션을 사용하기 위해 `org.springframework.boot:spring-boot-starter-validation:3.0.2`를 추가하였습니다.
## Screenshots (if appropriate):
