### PR TITLE
bug: return unauthorized when undefined error occurs

### DIFF
--- a/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
@@ -4,6 +4,7 @@ import com.dnd.wedding.global.response.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -65,5 +66,14 @@ public class ControllerExceptionHandler {
         ex.getMessage());
 
     return new ResponseEntity<>(message, HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  protected ResponseEntity<ErrorResponse> handleNotBlankValid(MethodArgumentNotValidException ex) {
+    ErrorResponse message = new ErrorResponse(
+        HttpStatus.BAD_REQUEST.value(),
+        ex.getBindingResult().getAllErrors().get(0).getDefaultMessage());
+
+    return new ResponseEntity<>(message, HttpStatus.BAD_REQUEST);
   }
 }

--- a/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
@@ -69,7 +69,8 @@ public class ControllerExceptionHandler {
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
-  protected ResponseEntity<ErrorResponse> methodArgumentNotValidException(MethodArgumentNotValidException ex) {
+  protected ResponseEntity<ErrorResponse> methodArgumentNotValidException(
+      MethodArgumentNotValidException ex) {
     ErrorResponse message = new ErrorResponse(
         HttpStatus.BAD_REQUEST.value(),
         ex.getAllErrors().get(0).getDefaultMessage());

--- a/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
@@ -69,7 +69,7 @@ public class ControllerExceptionHandler {
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
-  protected ResponseEntity<ErrorResponse> handleNotBlankValid(MethodArgumentNotValidException ex) {
+  protected ResponseEntity<ErrorResponse> methodArgumentNotValidException(MethodArgumentNotValidException ex) {
     ErrorResponse message = new ErrorResponse(
         HttpStatus.BAD_REQUEST.value(),
         ex.getAllErrors().get(0).getDefaultMessage());

--- a/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
@@ -76,4 +76,13 @@ public class ControllerExceptionHandler {
 
     return new ResponseEntity<>(message, HttpStatus.BAD_REQUEST);
   }
+
+  @ExceptionHandler(Exception.class)
+  protected ResponseEntity<ErrorResponse> handleException(Exception ex) {
+    ErrorResponse message = new ErrorResponse(
+        HttpStatus.INTERNAL_SERVER_ERROR.value(),
+        ex.getMessage());
+
+    return new ResponseEntity<>(message, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
 }

--- a/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
@@ -3,6 +3,7 @@ package com.dnd.wedding.global.exception;
 import com.dnd.wedding.global.response.ErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -53,5 +54,16 @@ public class ControllerExceptionHandler {
         ex.getMessage());
 
     return new ResponseEntity<>(message, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  public ResponseEntity<ErrorResponse> httpRequestMethodNotSupportedException(
+      final HttpRequestMethodNotSupportedException ex) {
+
+    ErrorResponse message = new ErrorResponse(
+        HttpStatus.NOT_FOUND.value(),
+        ex.getMessage());
+
+    return new ResponseEntity<>(message, HttpStatus.NOT_FOUND);
   }
 }

--- a/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
+++ b/src/main/java/com/dnd/wedding/global/exception/ControllerExceptionHandler.java
@@ -72,7 +72,7 @@ public class ControllerExceptionHandler {
   protected ResponseEntity<ErrorResponse> handleNotBlankValid(MethodArgumentNotValidException ex) {
     ErrorResponse message = new ErrorResponse(
         HttpStatus.BAD_REQUEST.value(),
-        ex.getBindingResult().getAllErrors().get(0).getDefaultMessage());
+        ex.getAllErrors().get(0).getDefaultMessage());
 
     return new ResponseEntity<>(message, HttpStatus.BAD_REQUEST);
   }

--- a/src/test/java/com/dnd/wedding/domain/oauth/info/OAuth2UserInfoFactoryTest.java
+++ b/src/test/java/com/dnd/wedding/domain/oauth/info/OAuth2UserInfoFactoryTest.java
@@ -18,10 +18,10 @@ class OAuth2UserInfoFactoryTest {
     OAuth2Provider google = OAuth2Provider.GOOGLE;
 
     Map<String, Object> attributes = Map.of(
-        "sub", anyInt(),
-        "name", anyString(),
-        "email", anyString(),
-        "picture", anyString());
+        "sub", 1,
+        "name", "test_name",
+        "email", "test@test.com",
+        "picture", "test_picture");
 
     // when
     OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2Userinfo(google, attributes);
@@ -36,12 +36,12 @@ class OAuth2UserInfoFactoryTest {
     OAuth2Provider kakao = OAuth2Provider.KAKAO;
 
     Map<String, Object> profile = Map.of(
-        "nickname", anyString(),
-        "profile_image_url", anyString());
+        "nickname", "test_nickname",
+        "profile_image_url", "test_image_url");
     Map<String, Object> kakaoAccount = Map.of(
-        "email", anyString());
+        "email", "test@test.com");
     Map<String, Object> attributes = Map.of(
-        "id", anyInt(), "kakao_account", kakaoAccount, "profile", profile);
+        "id", 1, "kakao_account", kakaoAccount, "profile", profile);
 
     // when
     OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2Userinfo(kakao, attributes);

--- a/src/test/java/com/dnd/wedding/global/exception/ControllerExceptionHandlerTest.java
+++ b/src/test/java/com/dnd/wedding/global/exception/ControllerExceptionHandlerTest.java
@@ -2,13 +2,20 @@ package com.dnd.wedding.global.exception;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.dnd.wedding.global.response.ErrorResponse;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 
 class ControllerExceptionHandlerTest {
 
@@ -88,5 +95,26 @@ class ControllerExceptionHandlerTest {
 
     assertNotNull(error);
     assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, error.getStatusCode());
+  }
+
+  @Test
+  @DisplayName("MethodArgumentNotValidException 발생 테스트")
+  void methodArgumentNotValidExceptionTest() throws Exception {
+    String message = "MethodArgumentNotValidException Error";
+
+    MethodArgumentNotValidException exception = new MethodArgumentNotValidException(
+        mock(MethodParameter.class),
+        mock(BindingResult.class));
+
+    ObjectError e = mock(ObjectError.class);
+    when(exception.getAllErrors()).thenReturn(List.of(e));
+    when(e.getDefaultMessage()).thenReturn(message);
+
+    ResponseEntity<ErrorResponse> error = controllerExceptionHandler
+        .handleNotBlankValid(exception);
+
+    assertNotNull(error);
+    assertEquals(HttpStatus.BAD_REQUEST, error.getStatusCode());
+    assertEquals(message, error.getBody().getMessage());
   }
 }

--- a/src/test/java/com/dnd/wedding/global/exception/ControllerExceptionHandlerTest.java
+++ b/src/test/java/com/dnd/wedding/global/exception/ControllerExceptionHandlerTest.java
@@ -112,7 +112,7 @@ class ControllerExceptionHandlerTest {
     when(e.getDefaultMessage()).thenReturn(message);
 
     ResponseEntity<ErrorResponse> error = controllerExceptionHandler
-        .handleNotBlankValid(exception);
+        .methodArgumentNotValidException(exception);
 
     assertNotNull(error);
     assertEquals(HttpStatus.BAD_REQUEST, error.getStatusCode());

--- a/src/test/java/com/dnd/wedding/global/exception/ControllerExceptionHandlerTest.java
+++ b/src/test/java/com/dnd/wedding/global/exception/ControllerExceptionHandlerTest.java
@@ -79,4 +79,14 @@ class ControllerExceptionHandlerTest {
     assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, error.getStatusCode());
     assertEquals(message, error.getBody().getMessage());
   }
+
+  @Test
+  @DisplayName("Exception 발생 테스트")
+  void exceptionTest() {
+    ResponseEntity<ErrorResponse> error = controllerExceptionHandler.handleException(
+        new Exception());
+
+    assertNotNull(error);
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, error.getStatusCode());
+  }
 }

--- a/src/test/java/com/dnd/wedding/global/exception/ControllerExceptionHandlerTest.java
+++ b/src/test/java/com/dnd/wedding/global/exception/ControllerExceptionHandlerTest.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.ObjectError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
 class ControllerExceptionHandlerTest {
@@ -116,5 +117,18 @@ class ControllerExceptionHandlerTest {
     assertNotNull(error);
     assertEquals(HttpStatus.BAD_REQUEST, error.getStatusCode());
     assertEquals(message, error.getBody().getMessage());
+  }
+
+  @Test
+  @DisplayName("HttpRequestMethodNotSupportedException 발생 테스트")
+  void httpRequestMethodNotSupportedExceptionTest() throws Exception {
+    HttpRequestMethodNotSupportedException exception = mock(
+        HttpRequestMethodNotSupportedException.class);
+
+    ResponseEntity<ErrorResponse> error = controllerExceptionHandler
+        .httpRequestMethodNotSupportedException(exception);
+
+    assertNotNull(error);
+    assertEquals(HttpStatus.NOT_FOUND, error.getStatusCode());
   }
 }


### PR DESCRIPTION
## Related Issue
#62 
## Description
spring security로 인해 다른 에러임에도 `401 Unauthorized`을 반환하는 에러에 대한 handler를 추가하였습니다. 
- HttpRequestMethodNotSupportedException
- MethodArgumentNotValidException
- Exception
## Screenshots (if appropriate):
