### PR TITLE
refactor: improve custom user details structure

### DIFF
--- a/src/main/java/com/dnd/wedding/domain/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package com.dnd.wedding.domain.jwt;
 
 import com.dnd.wedding.domain.jwt.repository.RefreshTokenRedisRepository;
+import com.dnd.wedding.domain.member.Member;
 import com.dnd.wedding.domain.oauth.CustomUserDetails;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -109,8 +110,9 @@ public class JwtTokenProvider {
         Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
             .map(SimpleGrantedAuthority::new).toList();
 
-    CustomUserDetails principal = new CustomUserDetails(Long.valueOf(claims.getSubject()), "",
-        null, null, authorities);
+    CustomUserDetails principal = new CustomUserDetails(Member.builder()
+        .id(Long.valueOf(claims.getSubject()))
+        .build());
 
     return new UsernamePasswordAuthenticationToken(principal, "", authorities);
   }

--- a/src/main/java/com/dnd/wedding/domain/oauth/CustomUserDetails.java
+++ b/src/main/java/com/dnd/wedding/domain/oauth/CustomUserDetails.java
@@ -1,10 +1,8 @@
 package com.dnd.wedding.domain.oauth;
 
 import com.dnd.wedding.domain.member.Member;
-import com.dnd.wedding.domain.member.Role;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
@@ -15,50 +13,35 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 @Getter
 public class CustomUserDetails implements UserDetails, OAuth2User {
 
-  private final Long id;
-  private final String email;
-  private final OAuth2Provider oauth2Provider;
-  private final Role role;
-  private final Collection<? extends GrantedAuthority> authorities;
+  private Member member;
   private transient Map<String, Object> attributes;
 
-  public CustomUserDetails(Long id, String email, OAuth2Provider oauth2Provider, Role role,
-      Collection<? extends GrantedAuthority> authorities) {
-    this.id = id;
-    this.email = email;
-    this.oauth2Provider = oauth2Provider;
-    this.role = role;
-    this.authorities = authorities;
+  public CustomUserDetails(Member member) {
+    this.member = member;
   }
 
-  public static CustomUserDetails create(Member member) {
-    List<GrantedAuthority> authorities = Collections.singletonList(
-        new SimpleGrantedAuthority("ROLE_USER"));
-
-    return new CustomUserDetails(
-        member.getId(),
-        member.getEmail(),
-        member.getOauth2Provider(),
-        Role.USER,
-        authorities
-    );
-  }
-
-  public static CustomUserDetails create(Member member, Map<String, Object> attributes) {
-    CustomUserDetails userDetails = CustomUserDetails.create(member);
-    userDetails.setAttributes(attributes);
-    return userDetails;
+  public CustomUserDetails(Member member, Map<String, Object> attributes) {
+    this.member = member;
+    this.attributes = attributes;
   }
 
   // UserDetail Override
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    return authorities;
+    return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+  }
+
+  public Long getId() {
+    return member.getId();
+  }
+
+  public String getEmail() {
+    return member.getEmail();
   }
 
   @Override
   public String getUsername() {
-    return email;
+    return member.getName();
   }
 
   @Override
@@ -89,7 +72,7 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
   // OAuth2User Override
   @Override
   public String getName() {
-    return String.valueOf(id);
+    return String.valueOf(member.getId());
   }
 
   @Override

--- a/src/main/java/com/dnd/wedding/domain/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/dnd/wedding/domain/oauth/service/CustomOAuth2UserService.java
@@ -25,8 +25,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
   private final MemberRepository memberRepository;
 
   @Override
-  public OAuth2User loadUser(OAuth2UserRequest userRequest)
-      throws OAuth2AuthenticationException {
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
     OAuth2User oauth2User = super.loadUser(userRequest);
 
     try {
@@ -59,7 +58,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     } else {
       member = createMember(userInfo, oauth2Provider);
     }
-    return CustomUserDetails.create(member, oauth2User.getAttributes());
+    return new CustomUserDetails(member, oauth2User.getAttributes());
   }
 
   private Member createMember(OAuth2UserInfo userInfo, OAuth2Provider oauth2Provider) {

--- a/src/main/java/com/dnd/wedding/domain/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/dnd/wedding/domain/oauth/service/CustomOAuth2UserService.java
@@ -38,6 +38,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
   }
 
   private OAuth2User processOAuth2User(OAuth2UserRequest userRequest, OAuth2User oauth2User) {
+
     OAuth2Provider oauth2Provider = OAuth2Provider.valueOf(
         userRequest.getClientRegistration().getRegistrationId().toUpperCase());
     OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2Userinfo(oauth2Provider,
@@ -46,9 +47,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     if (userInfo.getEmail().isEmpty()) {
       throw new OAuthProcessingException("Email not found from OAuth2 provider");
     }
-    Optional<Member> memberOptional = memberRepository.findByEmail(userInfo.getEmail());
-    Member member;
 
+    Optional<Member> memberOptional = memberRepository.findByEmail(userInfo.getEmail());
+
+    Member member;
     if (memberOptional.isPresent()) {
       member = memberOptional.get();
       if (oauth2Provider != member.getOauth2Provider()) {
@@ -58,16 +60,19 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     } else {
       member = createMember(userInfo, oauth2Provider);
     }
+
     return new CustomUserDetails(member, oauth2User.getAttributes());
   }
 
   private Member createMember(OAuth2UserInfo userInfo, OAuth2Provider oauth2Provider) {
-    return memberRepository.save(Member.builder()
+    return memberRepository.save(
+      Member.builder()
         .email(userInfo.getEmail())
         .name(userInfo.getName())
         .profileImage(userInfo.getImageUrl())
         .role(Role.USER)
         .oauth2Provider(oauth2Provider)
-        .build());
+        .build()
+    );
   }
 }

--- a/src/test/java/com/dnd/wedding/domain/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/dnd/wedding/domain/jwt/JwtTokenProviderTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.dnd.wedding.domain.jwt.repository.RefreshTokenRedisRepository;
+import com.dnd.wedding.domain.member.Member;
 import com.dnd.wedding.domain.member.Role;
 import com.dnd.wedding.domain.oauth.CustomUserDetails;
 import com.dnd.wedding.domain.oauth.OAuth2Provider;
@@ -16,8 +17,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import javax.crypto.SecretKey;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,21 +25,23 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseCookie;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 class JwtTokenProviderTest {
 
   private static final String SECRET =
       "testSecretKeytestSecretKeytestSecretKeytestSecretKeytestSecretKeytestSecretKeytestSecretKey";
-  private static final Collection<? extends GrantedAuthority> authority = Collections.singletonList(
-      new SimpleGrantedAuthority("ROLE_USER"));
 
   private final RefreshTokenRedisRepository refreshTokenRedisRepository = mock(
       RefreshTokenRedisRepository.class);
-  private final CustomUserDetails customUserDetailsObject = new CustomUserDetails(1L,
-      "test@test.com",
-      OAuth2Provider.GOOGLE, Role.USER, authority);
+  private final CustomUserDetails customUserDetailsObject =
+      new CustomUserDetails(
+          Member.builder()
+              .id(1L)
+              .email("test@test.com")
+              .name("test")
+              .role(Role.USER)
+              .oauth2Provider(OAuth2Provider.GOOGLE)
+              .build());
 
   private JwtTokenProvider jwtTokenProvider;
   private SecretKey secretKey;

--- a/src/test/java/com/dnd/wedding/domain/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/dnd/wedding/domain/jwt/service/JwtServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import com.dnd.wedding.domain.jwt.JwtTokenProvider;
 import com.dnd.wedding.domain.jwt.RefreshToken;
 import com.dnd.wedding.domain.jwt.repository.RefreshTokenRedisRepository;
+import com.dnd.wedding.domain.member.Member;
 import com.dnd.wedding.domain.member.Role;
 import com.dnd.wedding.domain.oauth.CustomUserDetails;
 import com.dnd.wedding.domain.oauth.OAuth2Provider;
@@ -33,8 +34,14 @@ class JwtServiceTest {
   private final String cookieKey = "testCookieKey";
   private final String oldRefreshToken = "testRefreshToken";
   private final String oldAccessToken = "testAccessToken";
-  private final CustomUserDetails customUserDetails = new CustomUserDetails(1L, "test@test.com",
-      OAuth2Provider.GOOGLE, Role.USER, authority);
+  private final CustomUserDetails customUserDetails = new CustomUserDetails(
+      Member.builder()
+          .id(1L)
+          .email("test@test.com")
+          .name("test")
+          .role(Role.USER)
+          .oauth2Provider(OAuth2Provider.GOOGLE)
+          .build());
 
   private RefreshTokenRedisRepository refreshTokenRedisRepository;
   private JwtTokenProvider tokenProvider;

--- a/src/test/java/com/dnd/wedding/domain/oauth/CustomUserDetailsTest.java
+++ b/src/test/java/com/dnd/wedding/domain/oauth/CustomUserDetailsTest.java
@@ -22,16 +22,18 @@ import org.springframework.test.context.event.annotation.BeforeTestClass;
 
 class CustomUserDetailsTest {
 
-  private static final Collection<? extends GrantedAuthority> authority = Collections.singletonList(
-      new SimpleGrantedAuthority("ROLE_USER"));
+  private static final Collection<? extends GrantedAuthority> authority =
+      Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
 
-  private static final CustomUserDetails customUserDetailsObject = new CustomUserDetails(Member.builder()
-      .id(1L)
-      .email("test@test.com")
-      .name("test")
-      .role(Role.USER)
-      .oauth2Provider(OAuth2Provider.GOOGLE)
-      .build());
+  private static final CustomUserDetails customUserDetailsObject =
+      new CustomUserDetails(Member.builder()
+        .id(1L)
+        .email("test@test.com")
+        .name("test")
+        .role(Role.USER)
+        .oauth2Provider(OAuth2Provider.GOOGLE)
+        .build()
+      );
 
   private static MockedStatic<CustomUserDetails> customUserDetails;
 

--- a/src/test/java/com/dnd/wedding/domain/oauth/CustomUserDetailsTest.java
+++ b/src/test/java/com/dnd/wedding/domain/oauth/CustomUserDetailsTest.java
@@ -25,9 +25,13 @@ class CustomUserDetailsTest {
   private static final Collection<? extends GrantedAuthority> authority = Collections.singletonList(
       new SimpleGrantedAuthority("ROLE_USER"));
 
-  private static final CustomUserDetails customUserDetailsObject = new CustomUserDetails(1L,
-      "test@test.com",
-      OAuth2Provider.GOOGLE, Role.USER, authority);
+  private static final CustomUserDetails customUserDetailsObject = new CustomUserDetails(Member.builder()
+      .id(1L)
+      .email("test@test.com")
+      .name("test")
+      .role(Role.USER)
+      .oauth2Provider(OAuth2Provider.GOOGLE)
+      .build());
 
   private static MockedStatic<CustomUserDetails> customUserDetails;
 
@@ -51,13 +55,11 @@ class CustomUserDetailsTest {
   @Test
   @DisplayName("Member 객체를 통한 CustomUserDetails 생성")
   void createCustomUserDetailsByMember() {
-    CustomUserDetails customUserDetails1 = CustomUserDetails.create(member);
+    CustomUserDetails customUserDetails1 = new CustomUserDetails(member);
 
     assertNotNull(customUserDetails1);
     assertEquals(member.getId(), customUserDetails1.getId());
     assertEquals(member.getEmail(), customUserDetails1.getEmail());
-    assertEquals(member.getOauth2Provider(), customUserDetails1.getOauth2Provider());
-    assertEquals(Role.USER, customUserDetails1.getRole());
     assertEquals(authority, customUserDetails1.getAuthorities());
   }
 
@@ -65,13 +67,11 @@ class CustomUserDetailsTest {
   @DisplayName("Member 객체와 Attributes를 통한 CustomUserDetails 생성")
   void createCustomUserDetailsByMemberAndAttributes() {
     Map<String, Object> attributes = new HashMap<>();
-    CustomUserDetails customUserDetails1 = CustomUserDetails.create(member, attributes);
+    CustomUserDetails customUserDetails1 = new CustomUserDetails(member, attributes);
 
     assertNotNull(customUserDetails1);
     assertEquals(member.getId(), customUserDetails1.getId());
     assertEquals(member.getEmail(), customUserDetails1.getEmail());
-    assertEquals(member.getOauth2Provider(), customUserDetails1.getOauth2Provider());
-    assertEquals(Role.USER, customUserDetails1.getRole());
     assertEquals(authority, customUserDetails1.getAuthorities());
     assertEquals(attributes, customUserDetails1.getAttributes());
   }
@@ -83,9 +83,15 @@ class CustomUserDetailsTest {
   }
 
   @Test
-  @DisplayName("Email 조회")
+  @DisplayName("Username 조회")
   void getUsername() {
-    assertEquals("test@test.com", customUserDetailsObject.getUsername());
+    assertEquals("test", customUserDetailsObject.getUsername());
+  }
+
+  @Test
+  @DisplayName("Email 조회")
+  void getEmail() {
+    assertEquals("test@test.com", customUserDetailsObject.getEmail());
   }
 
   @Test
@@ -128,7 +134,7 @@ class CustomUserDetailsTest {
   @DisplayName("Attributes 조회")
   void getAttributes() {
     Map<String, Object> attributes = new HashMap<>();
-    CustomUserDetails customUserDetails1 = CustomUserDetails.create(member, attributes);
+    CustomUserDetails customUserDetails1 = new CustomUserDetails(member, attributes);
 
     assertEquals(attributes, customUserDetails1.getAttributes());
   }

--- a/src/test/java/com/dnd/wedding/global/WithMockOAuth2UserSecurityContextFactory.java
+++ b/src/test/java/com/dnd/wedding/global/WithMockOAuth2UserSecurityContextFactory.java
@@ -17,7 +17,7 @@ public class WithMockOAuth2UserSecurityContextFactory implements
     SecurityContext context = SecurityContextHolder.createEmptyContext();
 
     CustomUserDetails principal =
-        CustomUserDetails.create(Member.builder()
+        new CustomUserDetails(Member.builder()
             .id(1L)
             .name("testName")
             .email("test@test.com")


### PR DESCRIPTION
## Related Issue

#65 

## Description

- `CustomUserDetails` 구조 개선
  - 기존에 `getUserName()` 메서드가 이메일을 리턴했는데 코드 의미상 맞지 않다고 판단하여 해당 메서드는 실제 유저 이름을 반환하게 하였습니다.
  - 대신 추가적인 `getEmail()`이라는 메서드를 생성하였습니다.
  
## Screenshots (if appropriate):
