### PR TITLE
refactor: improve jwt token process

### DIFF
--- a/src/docs/asciidoc/api/Authorization.adoc
+++ b/src/docs/asciidoc/api/Authorization.adoc
@@ -1,0 +1,13 @@
+== 인가 API
+:doctype: book
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:seclinks:
+
+=== 엑세스 토큰 재발급
+
+Access Token이 만료된 경우 ``Refresh Token``을 이용하여 ``새로운 Access Token``을 발급받을 수 있습니다.
+주의할 점은 `만료된 Access Token` 또한 헤더에 포함시켜 보내야 한다는 것입니다.
+
+operation::jwt/refresh[snippets='http-request,http-response,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -4,3 +4,5 @@
 :toc: left
 :toclevels: 2
 :seclinks:
+
+include::api/Authorization.adoc[]

--- a/src/main/java/com/dnd/wedding/domain/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/JwtAuthenticationFilter.java
@@ -11,7 +11,6 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Log4j2
@@ -27,7 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     String accessToken = HeaderUtil.getAccessToken(request);
 
-    if (StringUtils.hasText(accessToken) && Boolean.TRUE.equals(tokenProvider.validateToken(accessToken))) {
+    if (Boolean.TRUE.equals(tokenProvider.validateToken(accessToken))) {
       Authentication authentication = tokenProvider.getAuthentication(accessToken);
       SecurityContextHolder.getContext().setAuthentication(authentication);
       log.debug("save: " + authentication.getName() + "credentials");

--- a/src/main/java/com/dnd/wedding/domain/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.dnd.wedding.domain.jwt;
 
+import static com.dnd.wedding.global.util.HeaderUtil.parseBearerToken;
+
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -18,13 +20,11 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-  public static final String AUTHORIZATION_HEADER = "Authorization";
   private final JwtTokenProvider tokenProvider;
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-      FilterChain filterChain)
-      throws ServletException, IOException {
+      FilterChain filterChain) throws ServletException, IOException {
 
     String token = parseBearerToken(request);
 
@@ -37,14 +37,5 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     filterChain.doFilter(request, response);
-  }
-
-  private String parseBearerToken(HttpServletRequest request) {
-    String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-
-    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-      return bearerToken.substring(7);
-    }
-    return null;
   }
 }

--- a/src/main/java/com/dnd/wedding/domain/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/JwtAuthenticationFilter.java
@@ -1,7 +1,6 @@
 package com.dnd.wedding.domain.jwt;
 
-import static com.dnd.wedding.global.util.HeaderUtil.parseBearerToken;
-
+import com.dnd.wedding.global.util.HeaderUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,10 +25,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
       FilterChain filterChain) throws ServletException, IOException {
 
-    String token = parseBearerToken(request);
+    String accessToken = HeaderUtil.getAccessToken(request);
 
-    if (StringUtils.hasText(token) && Boolean.TRUE.equals(tokenProvider.validateToken(token))) {
-      Authentication authentication = tokenProvider.getAuthentication(token);
+    if (StringUtils.hasText(accessToken) && Boolean.TRUE.equals(tokenProvider.validateToken(accessToken))) {
+      Authentication authentication = tokenProvider.getAuthentication(accessToken);
       SecurityContextHolder.getContext().setAuthentication(authentication);
       log.debug("save: " + authentication.getName() + "credentials");
     } else {

--- a/src/main/java/com/dnd/wedding/domain/jwt/controller/JwtController.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/controller/JwtController.java
@@ -1,5 +1,6 @@
 package com.dnd.wedding.domain.jwt.controller;
 
+import com.dnd.wedding.domain.jwt.dto.AccessTokenResponse;
 import com.dnd.wedding.domain.jwt.service.JwtService;
 import com.dnd.wedding.global.exception.UnauthorizedException;
 import com.dnd.wedding.global.response.SuccessResponse;
@@ -31,7 +32,7 @@ public class JwtController {
     }
 
     return ResponseEntity.ok().body(
-        SuccessResponse.builder().data(newToken).build()
+        SuccessResponse.builder().data(new AccessTokenResponse(newToken)).build()
     );
   }
 }

--- a/src/main/java/com/dnd/wedding/domain/jwt/controller/JwtController.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/controller/JwtController.java
@@ -1,11 +1,11 @@
 package com.dnd.wedding.domain.jwt.controller;
 
 import com.dnd.wedding.domain.jwt.service.JwtService;
+import com.dnd.wedding.global.exception.UnauthorizedException;
 import io.lettuce.core.dynamic.annotation.Param;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,9 +24,10 @@ public class JwtController {
 
     String newToken = jwtService.refreshToken(request, response, accessToken);
 
-    if (newToken != null) {
-      return ResponseEntity.ok().body(newToken);
+    if (newToken == null) {
+      throw new UnauthorizedException("Failed renew access token");
     }
-    return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Failed renew access token");
+
+    return ResponseEntity.ok().body(newToken);
   }
 }

--- a/src/main/java/com/dnd/wedding/domain/jwt/controller/JwtController.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/controller/JwtController.java
@@ -2,6 +2,7 @@ package com.dnd.wedding.domain.jwt.controller;
 
 import com.dnd.wedding.domain.jwt.service.JwtService;
 import com.dnd.wedding.global.exception.UnauthorizedException;
+import com.dnd.wedding.global.response.SuccessResponse;
 import io.lettuce.core.dynamic.annotation.Param;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -19,7 +20,7 @@ public class JwtController {
   private final JwtService jwtService;
 
   @GetMapping("/refresh")
-  public ResponseEntity<String> refreshToken(HttpServletRequest request,
+  public ResponseEntity<SuccessResponse> refreshToken(HttpServletRequest request,
       HttpServletResponse response, @Param("accessToken") String accessToken) {
 
     String newToken = jwtService.refreshToken(request, response, accessToken);
@@ -28,6 +29,8 @@ public class JwtController {
       throw new UnauthorizedException("Failed renew access token");
     }
 
-    return ResponseEntity.ok().body(newToken);
+    return ResponseEntity.ok().body(
+        SuccessResponse.builder().data(newToken).build()
+    );
   }
 }

--- a/src/main/java/com/dnd/wedding/domain/jwt/controller/JwtController.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/controller/JwtController.java
@@ -3,12 +3,12 @@ package com.dnd.wedding.domain.jwt.controller;
 import com.dnd.wedding.domain.jwt.service.JwtService;
 import com.dnd.wedding.global.exception.UnauthorizedException;
 import com.dnd.wedding.global.response.SuccessResponse;
-import io.lettuce.core.dynamic.annotation.Param;
+import com.dnd.wedding.global.util.HeaderUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,10 +19,11 @@ public class JwtController {
 
   private final JwtService jwtService;
 
-  @GetMapping("/refresh")
+  @PostMapping("/refresh")
   public ResponseEntity<SuccessResponse> refreshToken(HttpServletRequest request,
-      HttpServletResponse response, @Param("accessToken") String accessToken) {
+      HttpServletResponse response) {
 
+    String accessToken = HeaderUtil.getAccessToken(request);
     String newToken = jwtService.refreshToken(request, response, accessToken);
 
     if (newToken == null) {

--- a/src/main/java/com/dnd/wedding/domain/jwt/dto/AccessTokenResponse.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/dto/AccessTokenResponse.java
@@ -1,0 +1,15 @@
+package com.dnd.wedding.domain.jwt.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AccessTokenResponse {
+
+  private String accessToken;
+
+  @Builder
+  public AccessTokenResponse(String accessToken) {
+    this.accessToken = accessToken;
+  }
+}

--- a/src/main/java/com/dnd/wedding/domain/jwt/repository/CookieAuthorizationRequestRepository.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/repository/CookieAuthorizationRequestRepository.java
@@ -1,6 +1,6 @@
 package com.dnd.wedding.domain.jwt.repository;
 
-import com.dnd.wedding.global.config.util.CookieUtil;
+import com.dnd.wedding.global.util.CookieUtil;
 import com.nimbusds.oauth2.sdk.util.StringUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/dnd/wedding/domain/jwt/service/JwtService.java
+++ b/src/main/java/com/dnd/wedding/domain/jwt/service/JwtService.java
@@ -4,7 +4,7 @@ import com.dnd.wedding.domain.jwt.JwtTokenProvider;
 import com.dnd.wedding.domain.jwt.RefreshToken;
 import com.dnd.wedding.domain.jwt.repository.RefreshTokenRedisRepository;
 import com.dnd.wedding.domain.oauth.CustomUserDetails;
-import com.dnd.wedding.global.config.util.CookieUtil;
+import com.dnd.wedding.global.util.CookieUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/dnd/wedding/domain/oauth/CustomUserDetails.java
+++ b/src/main/java/com/dnd/wedding/domain/oauth/CustomUserDetails.java
@@ -41,7 +41,7 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
 
   @Override
   public String getUsername() {
-    return member.getName();
+    return String.valueOf(member.getId());
   }
 
   @Override

--- a/src/main/java/com/dnd/wedding/domain/oauth/handler/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/dnd/wedding/domain/oauth/handler/OAuth2AuthenticationFailureHandler.java
@@ -3,7 +3,7 @@ package com.dnd.wedding.domain.oauth.handler;
 import static com.dnd.wedding.domain.jwt.repository.CookieAuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
 
 import com.dnd.wedding.domain.jwt.repository.CookieAuthorizationRequestRepository;
-import com.dnd.wedding.global.config.util.CookieUtil;
+import com.dnd.wedding.global.util.CookieUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/dnd/wedding/domain/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/dnd/wedding/domain/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -5,8 +5,8 @@ import static com.dnd.wedding.domain.jwt.repository.CookieAuthorizationRequestRe
 
 import com.dnd.wedding.domain.jwt.JwtTokenProvider;
 import com.dnd.wedding.domain.jwt.repository.CookieAuthorizationRequestRepository;
-import com.dnd.wedding.global.config.util.CookieUtil;
 import com.dnd.wedding.global.exception.BadRequestException;
+import com.dnd.wedding.global.util.CookieUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/dnd/wedding/domain/oauth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/dnd/wedding/domain/oauth/service/CustomUserDetailsService.java
@@ -1,0 +1,24 @@
+package com.dnd.wedding.domain.oauth.service;
+
+import com.dnd.wedding.domain.member.Member;
+import com.dnd.wedding.domain.member.MemberRepository;
+import com.dnd.wedding.domain.oauth.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+  private final MemberRepository memberRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+    Member member = memberRepository.findById(Long.valueOf(id))
+        .orElseThrow(() -> new UsernameNotFoundException("User Not Found with id: " + id));
+    return new CustomUserDetails(member);
+  }
+}

--- a/src/main/java/com/dnd/wedding/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/wedding/global/config/SecurityConfig.java
@@ -37,7 +37,6 @@ public class SecurityConfig {
 
     http.authorizeHttpRequests()
         .requestMatchers(HttpMethod.GET, "/oauth2/**").permitAll()
-        .requestMatchers("/api/v1/jwt/**").permitAll()
         .anyRequest().authenticated();
 
     http

--- a/src/main/java/com/dnd/wedding/global/util/CookieUtil.java
+++ b/src/main/java/com/dnd/wedding/global/util/CookieUtil.java
@@ -1,4 +1,4 @@
-package com.dnd.wedding.global.config.util;
+package com.dnd.wedding.global.util;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/dnd/wedding/global/util/HeaderUtil.java
+++ b/src/main/java/com/dnd/wedding/global/util/HeaderUtil.java
@@ -11,7 +11,7 @@ public class HeaderUtil {
     throw new IllegalStateException("Utility class");
   }
 
-  public static String parseBearerToken(HttpServletRequest request) {
+  public static String getAccessToken(HttpServletRequest request) {
     String bearerToken = request.getHeader(HEADER_AUTHORIZATION);
 
     if (bearerToken.startsWith(TOKEN_PREFIX)) {

--- a/src/main/java/com/dnd/wedding/global/util/HeaderUtil.java
+++ b/src/main/java/com/dnd/wedding/global/util/HeaderUtil.java
@@ -14,6 +14,10 @@ public class HeaderUtil {
   public static String getAccessToken(HttpServletRequest request) {
     String bearerToken = request.getHeader(HEADER_AUTHORIZATION);
 
+    if (bearerToken == null) {
+      return null;
+    }
+
     if (bearerToken.startsWith(TOKEN_PREFIX)) {
       return bearerToken.substring(TOKEN_PREFIX.length());
     }

--- a/src/main/java/com/dnd/wedding/global/util/HeaderUtil.java
+++ b/src/main/java/com/dnd/wedding/global/util/HeaderUtil.java
@@ -1,0 +1,23 @@
+package com.dnd.wedding.global.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class HeaderUtil {
+
+  private static final String HEADER_AUTHORIZATION = "Authorization";
+  private static final String TOKEN_PREFIX = "Bearer ";
+
+  private HeaderUtil() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  public static String parseBearerToken(HttpServletRequest request) {
+    String bearerToken = request.getHeader(HEADER_AUTHORIZATION);
+
+    if (bearerToken.startsWith(TOKEN_PREFIX)) {
+      return bearerToken.substring(TOKEN_PREFIX.length());
+    }
+
+    return null;
+  }
+}

--- a/src/test/java/com/dnd/wedding/domain/jwt/controller/JwtControllerTest.java
+++ b/src/test/java/com/dnd/wedding/domain/jwt/controller/JwtControllerTest.java
@@ -1,57 +1,61 @@
 package com.dnd.wedding.domain.jwt.controller;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.dnd.wedding.docs.springrestdocs.AbstractRestDocsTests;
+import com.dnd.wedding.domain.jwt.JwtTokenProvider;
 import com.dnd.wedding.domain.jwt.service.JwtService;
-import org.junit.jupiter.api.BeforeEach;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
-class JwtControllerTest {
+@WebMvcTest(JwtController.class)
+class JwtControllerTest extends AbstractRestDocsTests {
 
-  JwtController jwtController;
+  @MockBean
+  JwtTokenProvider jwtTokenProvider;
+
+  @MockBean
   JwtService jwtService;
-  MockHttpServletRequest request;
-  MockHttpServletResponse response;
-
-  @BeforeEach
-  void init() {
-    jwtService = mock(JwtService.class);
-    jwtController = new JwtController(jwtService);
-    request = new MockHttpServletRequest();
-    response = new MockHttpServletResponse();
-  }
 
   @Test
   @DisplayName("access token 갱신 성공 시 새로 발급한 token을 전달한다.")
-  void successRenewAccessToken() {
-    // given
-    given(jwtService.refreshToken(request, response, "accessToken")).willReturn("token");
+  void refresh() throws Exception {
 
-    // when
-    ResponseEntity responseEntity = jwtController.refreshToken(request, response, "accessToken");
+    Cookie cookie = new Cookie("refresh", "refreshToken");
+    given(jwtService.refreshToken(
+        any(HttpServletRequest.class), any(HttpServletResponse.class), eq("accessToken")
+    )).willReturn("newAccessToken");
 
-    // then
-    assertEquals("token", responseEntity.getBody());
-    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
-  }
-
-  @Test
-  @DisplayName("access token 갱신 실패 시 401 코드가 전달된다.")
-  void failRenewAccessToken() {
-    // given
-    given(jwtService.refreshToken(request, response, "accessToken")).willReturn(null);
-
-    // when
-    ResponseEntity responseEntity = jwtController.refreshToken(request, response, "accessToken");
-
-    // then
-    assertEquals(HttpStatus.UNAUTHORIZED, responseEntity.getStatusCode());
+    mockMvc.perform(get("/api/v1/jwt/refresh?accessToken=accessToken").cookie(cookie))
+        .andExpect(status().isOk())
+        .andDo(document("jwt/refresh",
+            requestCookies(
+                cookieWithName("refresh").description("refresh token")
+            ),
+            queryParameters(
+                parameterWithName("accessToken").description("갱신할 access token")
+            ),
+            responseFields(
+                fieldWithPath("status").description("응답 상태 코드"),
+                fieldWithPath("message").description("응답 메시지"),
+                fieldWithPath("data").description("응답 데이터")
+            )
+        ));
   }
 }

--- a/src/test/java/com/dnd/wedding/domain/jwt/controller/JwtControllerTest.java
+++ b/src/test/java/com/dnd/wedding/domain/jwt/controller/JwtControllerTest.java
@@ -5,12 +5,12 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.dnd.wedding.docs.springrestdocs.AbstractRestDocsTests;
@@ -37,19 +37,20 @@ class JwtControllerTest extends AbstractRestDocsTests {
   @DisplayName("access token 갱신 성공 시 새로 발급한 token을 전달한다.")
   void refresh() throws Exception {
 
-    Cookie cookie = new Cookie("refresh", "refreshToken");
     given(jwtService.refreshToken(
         any(HttpServletRequest.class), any(HttpServletResponse.class), eq("accessToken")
     )).willReturn("newAccessToken");
 
-    mockMvc.perform(get("/api/v1/jwt/refresh?accessToken=accessToken").cookie(cookie))
+    mockMvc.perform(post("/api/v1/jwt/refresh")
+            .cookie(new Cookie("refresh", "refreshToken"))
+            .header("Authorization", "Bearer " + "accessToken"))
         .andExpect(status().isOk())
         .andDo(document("jwt/refresh",
             requestCookies(
                 cookieWithName("refresh").description("refresh token")
             ),
-            queryParameters(
-                parameterWithName("accessToken").description("갱신할 access token")
+            requestHeaders(
+                headerWithName("Authorization").description("access token")
             ),
             responseFields(
                 fieldWithPath("status").description("응답 상태 코드"),

--- a/src/test/java/com/dnd/wedding/domain/jwt/controller/JwtControllerTest.java
+++ b/src/test/java/com/dnd/wedding/domain/jwt/controller/JwtControllerTest.java
@@ -55,7 +55,8 @@ class JwtControllerTest extends AbstractRestDocsTests {
             responseFields(
                 fieldWithPath("status").description("응답 상태 코드"),
                 fieldWithPath("message").description("응답 메시지"),
-                fieldWithPath("data").description("응답 데이터")
+                fieldWithPath("data").description("응답 데이터"),
+                fieldWithPath("data.accessToken").description("새로 발급한 access token")
             )
         ));
   }

--- a/src/test/java/com/dnd/wedding/domain/oauth/CustomUserDetailsTest.java
+++ b/src/test/java/com/dnd/wedding/domain/oauth/CustomUserDetailsTest.java
@@ -87,7 +87,7 @@ class CustomUserDetailsTest {
   @Test
   @DisplayName("Username 조회")
   void getUsername() {
-    assertEquals("test", customUserDetailsObject.getUsername());
+    assertEquals("1", customUserDetailsObject.getUsername());
   }
 
   @Test
@@ -129,7 +129,7 @@ class CustomUserDetailsTest {
   @Test
   @DisplayName("Id 조회")
   void getName() {
-    assertEquals(Long.toString(1L), customUserDetailsObject.getName());
+    assertEquals("1", customUserDetailsObject.getName());
   }
 
   @Test

--- a/src/test/java/com/dnd/wedding/global/util/CookieUtilTest.java
+++ b/src/test/java/com/dnd/wedding/global/util/CookieUtilTest.java
@@ -1,4 +1,4 @@
-package com.dnd.wedding.global.config.util;
+package com.dnd.wedding.global.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mockStatic;


### PR DESCRIPTION
## Related Issue

None

## Description

- `CustomUserDetailsService` 추가
- JwtProvider 내 `getAuthentication` 메서드가 유저 Principal을 가져올 때 loadUserByUsername 메서드를 이용하도록 수정
- util 패키지 경로 변경
  - `global/config/util` -> `global/util`
- 헤더 정보 파싱을 위한 HeaderUtil 추가
  - 기존의 `JwtAuthenticationFilter` 내 `parseBearerToken` 함수를 `getAccessToken`으로 변경 후 이동
- `AccessToken` 재발급 시 요청 메서드 `POST`로 변경
- `AccessToken` 재발급 시 응답 형식 `SuccessResponse`로 변경
- 문서화 페이지 생성



## Screenshots (if appropriate):
