### PR TITLE
build: change documentation deployment trigger

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -2,7 +2,7 @@ name: API Docs
 on:
   push:
     branches:
-      - main
+      - develop
 
 permissions:
   contents: read


### PR DESCRIPTION
## Related Issue

#71 

## Description

문서화 패이지 배포 기준을 `develop` 브랜치 머지로 변경합니다.

## Screenshots (if appropriate):
