### PR TITLE
hotfix: allow jwt refresh api without authenticated

### DIFF
--- a/src/main/java/com/dnd/wedding/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/wedding/global/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
 
     http.authorizeHttpRequests()
         .requestMatchers(HttpMethod.GET, "/oauth2/**").permitAll()
+        .requestMatchers(HttpMethod.POST, "/api/v1/jwt/refresh").permitAll()
         .anyRequest().authenticated();
 
     http


### PR DESCRIPTION
## Related Issue

None

## Description

JWT refresh api 요청시 액세스 토큰 만료를 검사하지 않도록 설정

## Screenshots (if appropriate):
