### PR TITLE
refactor: change dependency for member in checklist controller

### DIFF
--- a/src/main/java/com/dnd/wedding/domain/checklist/checklistitem/controller/ChecklistItemController.java
+++ b/src/main/java/com/dnd/wedding/domain/checklist/checklistitem/controller/ChecklistItemController.java
@@ -7,7 +7,7 @@ import com.dnd.wedding.domain.checklist.checklistitem.service.ChecklistItemServi
 import com.dnd.wedding.domain.checklist.checklistsubitem.dto.ChecklistSubItemDto;
 import com.dnd.wedding.domain.checklist.checklistsubitem.service.ChecklistSubItemService;
 import com.dnd.wedding.domain.member.Member;
-import com.dnd.wedding.domain.member.MemberRepository;
+import com.dnd.wedding.domain.member.service.MemberService;
 import com.dnd.wedding.domain.oauth.CustomUserDetails;
 import com.dnd.wedding.global.exception.InternalServerErrorException;
 import com.dnd.wedding.global.exception.NotFoundException;
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/checklist/item")
 public class ChecklistItemController {
 
-  private final MemberRepository memberRepository;
+  private final MemberService memberService;
   private final ChecklistItemService checklistItemService;
   private final ChecklistSubItemService checklistSubItemService;
 
@@ -56,7 +56,7 @@ public class ChecklistItemController {
   public ResponseEntity<SuccessResponse> createChecklistItem(
       @AuthenticationPrincipal CustomUserDetails user,
       @RequestBody @Valid ChecklistItemApiDto requestDto) {
-    Member member = memberRepository.findById(user.getId())
+    Member member = memberService.findMember(user.getId())
         .orElseThrow(() -> new NotFoundException("not found user"));
     ChecklistItemApiDto savedChecklistItem = checklistItemService.createChecklistItem(
         requestDto, member);

--- a/src/main/java/com/dnd/wedding/domain/checklist/controller/ChecklistController.java
+++ b/src/main/java/com/dnd/wedding/domain/checklist/controller/ChecklistController.java
@@ -3,7 +3,7 @@ package com.dnd.wedding.domain.checklist.controller;
 import com.dnd.wedding.domain.checklist.checklistitem.dto.ChecklistItemApiDto;
 import com.dnd.wedding.domain.checklist.service.ChecklistService;
 import com.dnd.wedding.domain.member.Member;
-import com.dnd.wedding.domain.member.MemberRepository;
+import com.dnd.wedding.domain.member.service.MemberService;
 import com.dnd.wedding.domain.oauth.CustomUserDetails;
 import com.dnd.wedding.global.exception.NotFoundException;
 import com.dnd.wedding.global.response.SuccessResponse;
@@ -20,13 +20,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/checklist")
 public class ChecklistController {
 
-  private final MemberRepository memberRepository;
+  private final MemberService memberService;
   private final ChecklistService checklistService;
 
   @GetMapping
   public ResponseEntity<SuccessResponse> getChecklist(
       @AuthenticationPrincipal CustomUserDetails user) {
-    Member member = memberRepository.findById(user.getId())
+    Member member = memberService.findMember(user.getId())
         .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자입니다."));
 
     List<ChecklistItemApiDto> result = checklistService.findChecklist(member.getId());

--- a/src/main/java/com/dnd/wedding/domain/member/service/MemberService.java
+++ b/src/main/java/com/dnd/wedding/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.dnd.wedding.domain.member.service;
 
 import com.dnd.wedding.domain.member.Gender;
+import com.dnd.wedding.domain.member.Member;
 import java.util.Optional;
 
 public interface MemberService {
@@ -14,4 +15,6 @@ public interface MemberService {
   void putProfileImage(Long id, String url);
 
   boolean withdraw(Long id);
+
+  Optional<Member> findMember(Long id);
 }

--- a/src/main/java/com/dnd/wedding/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/dnd/wedding/domain/member/service/impl/MemberServiceImpl.java
@@ -53,4 +53,9 @@ public class MemberServiceImpl implements MemberService {
         })
         .orElse(false);
   }
+
+  @Override
+  public Optional<Member> findMember(Long id) {
+    return memberRepository.findById(id);
+  }
 }

--- a/src/test/java/com/dnd/wedding/domain/checklist/checklistitem/controller/ChecklistItemControllerTest.java
+++ b/src/test/java/com/dnd/wedding/domain/checklist/checklistitem/controller/ChecklistItemControllerTest.java
@@ -26,8 +26,8 @@ import com.dnd.wedding.domain.checklist.checklistsubitem.dto.ChecklistSubItemDto
 import com.dnd.wedding.domain.checklist.checklistsubitem.service.ChecklistSubItemService;
 import com.dnd.wedding.domain.jwt.JwtTokenProvider;
 import com.dnd.wedding.domain.member.Member;
-import com.dnd.wedding.domain.member.MemberRepository;
 import com.dnd.wedding.domain.member.Role;
+import com.dnd.wedding.domain.member.service.MemberService;
 import com.dnd.wedding.domain.oauth.OAuth2Provider;
 import com.dnd.wedding.global.WithMockOAuth2User;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,7 +55,7 @@ class ChecklistItemControllerTest extends AbstractRestDocsTests {
   @MockBean
   ChecklistSubItemService checklistSubItemService;
   @MockBean
-  MemberRepository memberRepository;
+  MemberService memberService;
   @MockBean
   JwtTokenProvider jwtTokenProvider;
 
@@ -193,7 +193,7 @@ class ChecklistItemControllerTest extends AbstractRestDocsTests {
         .build();
 
     // given
-    given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
+    given(memberService.findMember(anyLong())).willReturn(Optional.ofNullable(member));
     given(checklistItemService.createChecklistItem(any(ChecklistItemApiDto.class),
         any(Member.class))).willReturn(checklistItemApiDto);
 

--- a/src/test/java/com/dnd/wedding/domain/checklist/checklistsubitem/controller/ChecklistSubItemControllerTest.java
+++ b/src/test/java/com/dnd/wedding/domain/checklist/checklistsubitem/controller/ChecklistSubItemControllerTest.java
@@ -24,7 +24,7 @@ import com.dnd.wedding.domain.checklist.checklistsubitem.dto.ChecklistSubItemDto
 import com.dnd.wedding.domain.checklist.checklistsubitem.dto.ChecklistSubItemStateDto;
 import com.dnd.wedding.domain.checklist.checklistsubitem.service.ChecklistSubItemService;
 import com.dnd.wedding.domain.jwt.JwtTokenProvider;
-import com.dnd.wedding.domain.member.MemberRepository;
+import com.dnd.wedding.domain.member.service.MemberService;
 import com.dnd.wedding.global.WithMockOAuth2User;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -51,7 +51,7 @@ class ChecklistSubItemControllerTest extends AbstractRestDocsTests {
   @MockBean
   ChecklistSubItemService checklistSubItemService;
   @MockBean
-  MemberRepository memberRepository;
+  MemberService memberService;
   @MockBean
   JwtTokenProvider jwtTokenProvider;
 

--- a/src/test/java/com/dnd/wedding/domain/checklist/controller/ChecklistControllerTest.java
+++ b/src/test/java/com/dnd/wedding/domain/checklist/controller/ChecklistControllerTest.java
@@ -18,8 +18,8 @@ import com.dnd.wedding.domain.checklist.checklistsubitem.service.ChecklistSubIte
 import com.dnd.wedding.domain.checklist.service.ChecklistService;
 import com.dnd.wedding.domain.jwt.JwtTokenProvider;
 import com.dnd.wedding.domain.member.Member;
-import com.dnd.wedding.domain.member.MemberRepository;
 import com.dnd.wedding.domain.member.Role;
+import com.dnd.wedding.domain.member.service.MemberService;
 import com.dnd.wedding.domain.oauth.OAuth2Provider;
 import com.dnd.wedding.global.WithMockOAuth2User;
 import java.time.LocalDate;
@@ -43,7 +43,7 @@ class ChecklistControllerTest extends AbstractRestDocsTests {
   @MockBean
   ChecklistSubItemService checklistSubItemService;
   @MockBean
-  MemberRepository memberRepository;
+  MemberService memberService;
   @MockBean
   JwtTokenProvider jwtTokenProvider;
 
@@ -89,7 +89,7 @@ class ChecklistControllerTest extends AbstractRestDocsTests {
         .build();
 
     // given
-    given(memberRepository.findById(anyLong())).willReturn(Optional.ofNullable(member));
+    given(memberService.findMember(anyLong())).willReturn(Optional.ofNullable(member));
     given(checklistService.findChecklist(anyLong())).willReturn(List.of(checklistItemApiDto1));
 
     // when


### PR DESCRIPTION
## Related Issue
None
## Description
`MemberService`의 `findMember` 함수를 추가하였습니다.
Checklist 관련 controller에서 사용하던 `MemberRepository`를 `MemberService`로 변경하였습니다.
## Screenshots (if appropriate):
