### PR TITLE
docs: change access token value in member api

### DIFF
--- a/src/test/java/com/dnd/wedding/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/dnd/wedding/domain/member/controller/MemberControllerTest.java
@@ -66,7 +66,7 @@ class MemberControllerTest extends AbstractRestDocsTests {
 
     // when
     ResultActions result = mockMvc.perform(get("/api/v1/user/gender")
-        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "accessToken"));
+        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "ACCESS_TOKEN"));
 
     // then
     result.andExpect(status().isOk())
@@ -93,7 +93,7 @@ class MemberControllerTest extends AbstractRestDocsTests {
 
     // when
     ResultActions result = mockMvc.perform(post("/api/v1/user/gender")
-        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "accessToken")
+        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "ACCESS_TOKEN")
         .content(objectMapper.writeValueAsString(dto))
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
@@ -127,7 +127,7 @@ class MemberControllerTest extends AbstractRestDocsTests {
 
     // when
     ResultActions result = mockMvc.perform(get("/api/v1/user/profile")
-        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "accessToken"));
+        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "ACCESS_TOKEN"));
 
     // then
     result.andExpect(status().isOk())
@@ -157,7 +157,7 @@ class MemberControllerTest extends AbstractRestDocsTests {
     // when
     ResultActions result = mockMvc.perform(multipart("/api/v1/user/profile")
         .file(image)
-        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "accessToken")
+        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "ACCESS_TOKEN")
         .contentType(MediaType.MULTIPART_FORM_DATA)
         .accept(MediaType.APPLICATION_JSON)
     );
@@ -189,7 +189,7 @@ class MemberControllerTest extends AbstractRestDocsTests {
 
     // when
     ResultActions result = mockMvc.perform(delete("/api/v1/user")
-        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "accessToken"));
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + "accessToken"));
 
     // then
     result.andExpect(status().isOk())

--- a/src/test/java/com/dnd/wedding/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/dnd/wedding/domain/member/controller/MemberControllerTest.java
@@ -41,6 +41,8 @@ import org.springframework.web.multipart.MultipartFile;
 @WebMvcTest(MemberController.class)
 class MemberControllerTest extends AbstractRestDocsTests {
 
+  static final String ACCESS_TOKEN_PREFIX = "Bearer ";
+
   @MockBean
   JwtTokenProvider jwtTokenProvider;
 
@@ -64,7 +66,7 @@ class MemberControllerTest extends AbstractRestDocsTests {
 
     // when
     ResultActions result = mockMvc.perform(get("/api/v1/user/gender")
-        .header(HttpHeaders.AUTHORIZATION, "Bearer " + "accessToken"));
+        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "accessToken"));
 
     // then
     result.andExpect(status().isOk())
@@ -91,7 +93,7 @@ class MemberControllerTest extends AbstractRestDocsTests {
 
     // when
     ResultActions result = mockMvc.perform(post("/api/v1/user/gender")
-        .header(HttpHeaders.AUTHORIZATION, "Bearer " + "accessToken")
+        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "accessToken")
         .content(objectMapper.writeValueAsString(dto))
         .contentType(MediaType.APPLICATION_JSON)
         .accept(MediaType.APPLICATION_JSON)
@@ -125,7 +127,7 @@ class MemberControllerTest extends AbstractRestDocsTests {
 
     // when
     ResultActions result = mockMvc.perform(get("/api/v1/user/profile")
-        .header(HttpHeaders.AUTHORIZATION, "Bearer " + "accessToken"));
+        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "accessToken"));
 
     // then
     result.andExpect(status().isOk())
@@ -155,7 +157,7 @@ class MemberControllerTest extends AbstractRestDocsTests {
     // when
     ResultActions result = mockMvc.perform(multipart("/api/v1/user/profile")
         .file(image)
-        .header(HttpHeaders.AUTHORIZATION, "Bearer " + "accessToken")
+        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "accessToken")
         .contentType(MediaType.MULTIPART_FORM_DATA)
         .accept(MediaType.APPLICATION_JSON)
     );
@@ -187,7 +189,7 @@ class MemberControllerTest extends AbstractRestDocsTests {
 
     // when
     ResultActions result = mockMvc.perform(delete("/api/v1/user")
-        .header(HttpHeaders.AUTHORIZATION, "Bearer " + "accessToken"));
+        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "accessToken"));
 
     // then
     result.andExpect(status().isOk())


### PR DESCRIPTION
## Related Issue

None

## Description

사용자 API의 액세스 토큰 값을 변경하였습니다.
`accessToken` -> `ACCESS_TOKEN`

## Screenshots (if appropriate):
