### PR TITLE
test(checklist): change time to actual value

### DIFF
--- a/src/test/java/com/dnd/wedding/domain/checklist/checklistitem/controller/ChecklistItemControllerTest.java
+++ b/src/test/java/com/dnd/wedding/domain/checklist/checklistitem/controller/ChecklistItemControllerTest.java
@@ -67,8 +67,8 @@ class ChecklistItemControllerTest extends AbstractRestDocsTests {
       .id(1L)
       .title("title")
       .checkDate(LocalDate.now())
-      .startTime(LocalTime.now())
-      .endTime(LocalTime.now())
+      .startTime(LocalTime.of(1, 1, 1))
+      .endTime(LocalTime.of(12, 11, 14))
       .place("place")
       .memo("memo")
       .build();
@@ -77,8 +77,8 @@ class ChecklistItemControllerTest extends AbstractRestDocsTests {
       .id(1L)
       .title("title")
       .checkDate(LocalDate.now())
-      .startTime(LocalTime.now())
-      .endTime(LocalTime.now())
+      .startTime(LocalTime.of(1, 1, 1))
+      .endTime(LocalTime.of(12, 11, 14))
       .place("place")
       .memo("memo")
       .build();
@@ -177,8 +177,8 @@ class ChecklistItemControllerTest extends AbstractRestDocsTests {
     ChecklistItemDto createChecklistItemDto = ChecklistItemDto.builder()
         .title("title")
         .checkDate(LocalDate.now())
-        .startTime(LocalTime.now())
-        .endTime(LocalTime.now())
+        .startTime(LocalTime.of(1, 1, 1))
+        .endTime(LocalTime.of(12, 11, 14))
         .place("place")
         .memo("memo")
         .build();

--- a/src/test/java/com/dnd/wedding/domain/checklist/controller/ChecklistControllerTest.java
+++ b/src/test/java/com/dnd/wedding/domain/checklist/controller/ChecklistControllerTest.java
@@ -54,8 +54,8 @@ class ChecklistControllerTest extends AbstractRestDocsTests {
       .id(1L)
       .title("title")
       .checkDate(LocalDate.now())
-      .startTime(LocalTime.MIN)
-      .endTime(LocalTime.MAX)
+      .startTime(LocalTime.of(1, 1, 1))
+      .endTime(LocalTime.of(12, 11, 14))
       .place("place")
       .memo("memo")
       .build();


### PR DESCRIPTION
## Related Issue
None
## Description
`LocalTime.now()`나 `MIN`, `MAX` 등을 사용할 경우 api 문서에 ms까지 표기되는 문제가 있어 실제 구체적인 값으로 수정하였습니다.
## Screenshots (if appropriate):
