### PR TITLE
feat: onboarding checklist pre check api

### DIFF
--- a/src/docs/asciidoc/api/checklist/checklist.adoc
+++ b/src/docs/asciidoc/api/checklist/checklist.adoc
@@ -5,11 +5,28 @@
 :toclevels: 2
 :seclinks:
 
+사용자 체크리스트 조회 및 온보딩 체크리스트 사전 등록이 가능합니다.
+이를 위해서는 ``Header``의 ``Authorization``에 사용자의 ``액세스 토큰``을 포함시켜야 합니다.
+
 === 체크리스트 조회
 
 사용자의 ``전체 체크리스트``를 조회할 수 있습니다.
-이를 위해서는 ``Header``의 ``Authorization``에 사용자의 ``액세스 토큰``을 포함시켜야 합니다.
 
 사용자가 등록한 체크리스트 아이템과 체크리스트 서브 아이템 목록 전체를 조회할 수 있습니다.
 
 operation::checklist/checklist/[snippets="http-request,http-response,response-fields-data"]
+
+=== 온보딩 체크리스트 사전 등록
+
+온보딩 페이지에서 아직 진행하지 않은 일정에 대해 ``체크리스트 사전 등록``이 가능합니다.
+진행하지 않은 일정에 대해서는 아래에 정의된 String 값으로 요청을 보내야 합니다.
+
+- 상견례 MEETING
+- 예식장 WEDDING_HALL
+- 신혼여행 HONEYMOON
+- 스튜디오 STUDIO
+- 드레스 DRESS
+- 메이크업 MAKEUP
+- 예물 WEDDING_GIFT
+
+operation::checklist/pre-check/[snippets="http-request,request-fields,http-response,response-fields-data"]

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/PreChecklistItem.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/PreChecklistItem.java
@@ -1,0 +1,34 @@
+package com.dnd.weddingmap.domain.checklist;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+
+@Getter
+public enum PreChecklistItem {
+
+  MEETING("상견례"),
+  WEDDING_HALL("예식장"),
+  HONEYMOON("신혼여행"),
+  STUDIO("스튜디오"),
+  DRESS("드레스"),
+  MAKEUP("메이크업"),
+  WEDDING_GIFT("예물");
+
+  private final String title;
+
+  PreChecklistItem(String title) {
+    this.title = title;
+  }
+
+  @JsonCreator
+  public static PreChecklistItem findBy(String key) {
+
+    for (PreChecklistItem preChecklistItem : PreChecklistItem.values()) {
+      if (preChecklistItem.name().equals(key.toUpperCase())) {
+        return preChecklistItem;
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistController.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistController.java
@@ -1,17 +1,23 @@
 package com.dnd.weddingmap.domain.checklist.controller;
 
 import com.dnd.weddingmap.domain.checklist.checklistitem.dto.ChecklistItemApiDto;
+import com.dnd.weddingmap.domain.checklist.checklistitem.dto.ChecklistItemDto;
+import com.dnd.weddingmap.domain.checklist.dto.PreChecklistItemListDto;
 import com.dnd.weddingmap.domain.checklist.service.ChecklistService;
 import com.dnd.weddingmap.domain.member.Member;
 import com.dnd.weddingmap.domain.member.service.MemberService;
 import com.dnd.weddingmap.domain.oauth.CustomUserDetails;
 import com.dnd.weddingmap.global.exception.NotFoundException;
 import com.dnd.weddingmap.global.response.SuccessResponse;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,5 +37,20 @@ public class ChecklistController {
 
     List<ChecklistItemApiDto> result = checklistService.findChecklist(member.getId());
     return ResponseEntity.ok().body(SuccessResponse.builder().data(result).build());
+  }
+
+  @PostMapping("/pre-check")
+  public ResponseEntity<SuccessResponse> savePreChecklists(
+      @AuthenticationPrincipal CustomUserDetails user,
+      @RequestBody @Valid PreChecklistItemListDto preChecklistItemListDto) {
+    Member member = memberService.findMember(user.getId())
+        .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자입니다."));
+
+    List<ChecklistItemDto> result = checklistService.savePreChecklistItemList(member,
+        preChecklistItemListDto);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(
+        SuccessResponse.builder().httpStatus(HttpStatus.CREATED).message("체크리스트 사전 등록 성공")
+            .data(result).build());
   }
 }

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/dto/PreChecklistItemListDto.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/dto/PreChecklistItemListDto.java
@@ -1,0 +1,24 @@
+package com.dnd.weddingmap.domain.checklist.dto;
+
+import com.dnd.weddingmap.domain.checklist.PreChecklistItem;
+import com.dnd.weddingmap.global.validator.ValidEnum;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PreChecklistItemListDto {
+
+  @NotNull
+  private List<@ValidEnum(
+      value = PreChecklistItem.class, message = "preChecklistItem 항목을 다시 확인해주세요.")
+      PreChecklistItem> preChecklistItems;
+
+  @Builder
+  public PreChecklistItemListDto(List<PreChecklistItem> preChecklistItems) {
+    this.preChecklistItems = preChecklistItems;
+  }
+}

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/service/ChecklistService.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/service/ChecklistService.java
@@ -1,9 +1,15 @@
 package com.dnd.weddingmap.domain.checklist.service;
 
 import com.dnd.weddingmap.domain.checklist.checklistitem.dto.ChecklistItemApiDto;
+import com.dnd.weddingmap.domain.checklist.checklistitem.dto.ChecklistItemDto;
+import com.dnd.weddingmap.domain.checklist.dto.PreChecklistItemListDto;
+import com.dnd.weddingmap.domain.member.Member;
 import java.util.List;
 
 public interface ChecklistService {
 
   List<ChecklistItemApiDto> findChecklist(Long memberId);
+
+  List<ChecklistItemDto> savePreChecklistItemList(
+      Member member, PreChecklistItemListDto preChecklistItemListDto);
 }

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/service/impl/ChecklistServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/service/impl/ChecklistServiceImpl.java
@@ -7,7 +7,9 @@ import com.dnd.weddingmap.domain.checklist.checklistitem.repository.ChecklistIte
 import com.dnd.weddingmap.domain.checklist.checklistsubitem.ChecklistSubItem;
 import com.dnd.weddingmap.domain.checklist.checklistsubitem.dto.ChecklistSubItemDto;
 import com.dnd.weddingmap.domain.checklist.checklistsubitem.repository.ChecklistSubItemRepository;
+import com.dnd.weddingmap.domain.checklist.dto.PreChecklistItemListDto;
 import com.dnd.weddingmap.domain.checklist.service.ChecklistService;
+import com.dnd.weddingmap.domain.member.Member;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +32,18 @@ public class ChecklistServiceImpl implements ChecklistService {
     checklistItemList.forEach(item -> result.add(toDto(item, findChecklistSubItem(item.getId()))));
 
     return result;
+  }
+
+  @Transactional
+  @Override
+  public List<ChecklistItemDto> savePreChecklistItemList(Member member,
+      PreChecklistItemListDto preChecklistItemListDto) {
+    return preChecklistItemListDto.getPreChecklistItems().stream()
+        .map(preChecklistItem ->
+            new ChecklistItemDto(checklistItemRepository.save(ChecklistItem.builder()
+                .title(preChecklistItem.getTitle())
+                .member(member)
+                .build()))).toList();
   }
 
   public List<ChecklistSubItem> findChecklistSubItem(Long checklistItemId) {

--- a/src/test/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistControllerTest.java
+++ b/src/test/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistControllerTest.java
@@ -1,20 +1,27 @@
 package com.dnd.weddingmap.domain.checklist.controller;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.dnd.weddingmap.docs.springrestdocs.AbstractRestDocsTests;
+import com.dnd.weddingmap.domain.checklist.PreChecklistItem;
 import com.dnd.weddingmap.domain.checklist.checklistitem.dto.ChecklistItemApiDto;
 import com.dnd.weddingmap.domain.checklist.checklistitem.dto.ChecklistItemDto;
 import com.dnd.weddingmap.domain.checklist.checklistitem.service.ChecklistItemService;
 import com.dnd.weddingmap.domain.checklist.checklistsubitem.dto.ChecklistSubItemDto;
 import com.dnd.weddingmap.domain.checklist.checklistsubitem.service.ChecklistSubItemService;
+import com.dnd.weddingmap.domain.checklist.dto.PreChecklistItemListDto;
 import com.dnd.weddingmap.domain.checklist.service.ChecklistService;
 import com.dnd.weddingmap.domain.jwt.JwtTokenProvider;
 import com.dnd.weddingmap.domain.member.Member;
@@ -22,6 +29,7 @@ import com.dnd.weddingmap.domain.member.Role;
 import com.dnd.weddingmap.domain.member.service.MemberService;
 import com.dnd.weddingmap.domain.oauth.OAuth2Provider;
 import com.dnd.weddingmap.global.WithMockOAuth2User;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
@@ -31,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -76,20 +85,20 @@ class ChecklistControllerTest extends AbstractRestDocsTests {
       .checklistSubItems(List.of(checklistSubItemDto1, checklistSubItemDto2))
       .build();
 
+  private final Member member = Member.builder()
+      .id(1L)
+      .name("test")
+      .email("test@example.com")
+      .profileImage("test.png")
+      .role(Role.USER)
+      .oauth2Provider(OAuth2Provider.GOOGLE)
+      .build();
+
   @Test
   @WithMockOAuth2User
   @DisplayName("사용자 체크리스트 조회")
   void getChecklist() throws Exception {
     String url = "/api/v1/checklist";
-
-    Member member = Member.builder()
-        .id(1L)
-        .name("test")
-        .email("test@example.com")
-        .profileImage("test.png")
-        .role(Role.USER)
-        .oauth2Provider(OAuth2Provider.GOOGLE)
-        .build();
 
     // given
     given(memberService.findMember(anyLong())).willReturn(Optional.ofNullable(member));
@@ -131,6 +140,59 @@ class ChecklistControllerTest extends AbstractRestDocsTests {
                     fieldWithPath("checklistSubItems[].isChecked").description(
                         "체크리스트 서브 아이템 체크 여부").type(
                         JsonFieldType.BOOLEAN)
+                )
+            ));
+  }
+
+  @Test
+  @WithMockOAuth2User
+  @DisplayName("온보딩 사전 체크리스트 등록")
+  void savePreChecklistItems() throws Exception {
+    String url = "/api/v1/checklist/pre-check";
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    PreChecklistItemListDto preChecklistItemListDto = PreChecklistItemListDto.builder()
+        .preChecklistItems(List.of(PreChecklistItem.MAKEUP,
+            PreChecklistItem.HONEYMOON))
+        .build();
+
+    List<ChecklistItemDto> checklistItemDtoList = List.of(
+        ChecklistItemDto.builder().id(1L).title(PreChecklistItem.MAKEUP.getTitle()).build(),
+        ChecklistItemDto.builder().id(2L).title(PreChecklistItem.HONEYMOON.getTitle()).build());
+
+    // given
+    given(memberService.findMember(anyLong())).willReturn(Optional.ofNullable(member));
+    given(
+        checklistService.savePreChecklistItemList(any(Member.class),
+            any(PreChecklistItemListDto.class))).willReturn(checklistItemDtoList);
+
+    // when
+    ResultActions result = mockMvc.perform(post(url)
+        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "ACCESS_TOKEN")
+        .with(csrf())
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(objectMapper.writeValueAsString(preChecklistItemListDto)));
+
+    // then
+    result.andExpect(status().isCreated())
+        .andDo(
+            document("checklist/pre-check",
+                requestFields(
+                    fieldWithPath("preChecklistItems").description("선택되지 않은 사전 등록 아이템 리스트")
+                        .type(JsonFieldType.ARRAY)
+                ),
+                responseFields(
+                    beneathPath("data").withSubsectionId("data"),
+                    fieldWithPath("id").description("등록된 체크리스트 아이템 아이디").type(
+                        JsonFieldType.NUMBER),
+                    fieldWithPath("title").description("등록된 체크리스트 아이템 제목").type(
+                        JsonFieldType.STRING),
+                    fieldWithPath("checkDate").ignored(),
+                    fieldWithPath("startTime").ignored(),
+                    fieldWithPath("endTime").ignored(),
+                    fieldWithPath("place").ignored(),
+                    fieldWithPath("memo").ignored()
                 )
             ));
   }


### PR DESCRIPTION
## Related Issue
#84 
## Description
온보딩에서 사용할 체크리스트 사전 등록 api입니다.

온보딩 페이지에서 선택되지 않은 항목들에 대한 체크리스트를 사전 등록합니다.

- 상견례 **MEETING**
- 예식장 **WEDDING_HALL**
- 신혼여행 **HONEYMOON**
- 스튜디오 **STUDIO**
- 드레스 **DRESS**
- 메이크업 **MAKEUP**
- 예물 **WEDDING_GIFT**

## Screenshots (if appropriate):
