### PR TITLE
fix: change response data to sort by date

### DIFF
--- a/src/docs/asciidoc/api/checklist/checklist.adoc
+++ b/src/docs/asciidoc/api/checklist/checklist.adoc
@@ -14,6 +14,8 @@
 
 사용자가 등록한 체크리스트 아이템과 체크리스트 서브 아이템 목록 전체를 조회할 수 있습니다.
 
+응답 데이터는 ``체크리스트 아이템 일정 날짜 (checkDate)`` 에 맞추어 오름차순으로 정렬된 데이터이며, 일정 날짜가 입력되지 않은 데이터가 제일 앞쪽에 위치합니다.
+
 operation::checklist/checklist/[snippets="http-request,http-response,response-fields-data"]
 
 === 온보딩 체크리스트 사전 등록

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/checklistitem/repository/ChecklistItemRepository.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/checklistitem/repository/ChecklistItemRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChecklistItemRepository extends JpaRepository<ChecklistItem, Long> {
 
-  List<ChecklistItem> findByMemberId(Long id);
+  List<ChecklistItem> findByMemberIdOrderByCheckDate(Long id);
 }

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/service/impl/ChecklistServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/service/impl/ChecklistServiceImpl.java
@@ -26,7 +26,7 @@ public class ChecklistServiceImpl implements ChecklistService {
   @Transactional
   @Override
   public List<ChecklistItemApiDto> findChecklist(Long memberId) {
-    List<ChecklistItem> checklistItemList = checklistItemRepository.findByMemberId(
+    List<ChecklistItem> checklistItemList = checklistItemRepository.findByMemberIdOrderByCheckDate(
         memberId);
     List<ChecklistItemApiDto> result = new ArrayList<>();
     checklistItemList.forEach(item -> result.add(toDto(item, findChecklistSubItem(item.getId()))));

--- a/src/test/java/com/dnd/weddingmap/domain/checklist/checklistitem/repository/ChecklistItemRepositoryTest.java
+++ b/src/test/java/com/dnd/weddingmap/domain/checklist/checklistitem/repository/ChecklistItemRepositoryTest.java
@@ -73,7 +73,8 @@ class ChecklistItemRepositoryTest {
     checklistItemRepository.save(checklistItem1);
     checklistItemRepository.save(checklistItem2);
 
-    List<ChecklistItem> checklistItems = checklistItemRepository.findByMemberId(member.getId());
+    List<ChecklistItem> checklistItems = checklistItemRepository
+        .findByMemberIdOrderByCheckDate(member.getId());
 
     assertEquals(2, checklistItems.size());
   }


### PR DESCRIPTION
## Related Issue
None
## Description
체크리스트 조회 시 응답 데이터를 **일정 날짜(checkDate)** 순으로 정렬하여 보내도록 수정하였습니다.

## Screenshots (if appropriate):
