### PR TITLE
build: optimize GitHub actions

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 17
-          distribution: 'zulu'
+          distribution: 'temurin'
           cache: 'gradle'
       - name: Build Asciidoc
         run: ./gradlew asciidoctor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: 17
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,7 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+          cache: 'gradle'
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
## Related Issue

None

## Description

깃헙 액션 최적화 작업 진행

- 자바 배포판 `temurin`으로 변경
- `CI` 워크플로우 gradle 캐시를 `setup-java`의 설정으로 처리

## Screenshots (if appropriate):
