### PR TITLE
feature: health check api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security:3.0.1'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client:3.0.1'
     implementation 'org.springframework.boot:spring-boot-starter-validation:3.0.2'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator:3.0.2'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test:3.0.1'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:3.0.0'

--- a/src/main/java/com/dnd/weddingmap/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/weddingmap/global/config/SecurityConfig.java
@@ -36,6 +36,7 @@ public class SecurityConfig {
         .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
     http.authorizeHttpRequests()
+        .requestMatchers(HttpMethod.GET, "/actuator/health").permitAll()
         .requestMatchers(HttpMethod.GET, "/oauth2/**").permitAll()
         .requestMatchers(HttpMethod.POST, "/api/v1/jwt/refresh").permitAll()
         .anyRequest().authenticated();


### PR DESCRIPTION
## Related Issue

#96 

## Description

- health check api를 추가하기 위한 `Spring Boot Starter Actuator` 의존성 설정
- `/actuator/health` url 요청 모두 허용

`/actuator/health`로 GET 요청 시 Actuator는 서버가 정상 가동 중인지 확인하여 응답합니다.

## Screenshots (if appropriate):

<img width="1355" alt="스크린샷 2023-02-22 오후 2 45 57" src="https://user-images.githubusercontent.com/44942700/220533836-d4ee0a03-5be1-4692-a2e1-38d2d95fab89.png">

