### PR TITLE
fix: resolve out of memory on ecs container

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -33,8 +33,8 @@
         {
             "name": "application",
             "image": "339286557484.dkr.ecr.ap-northeast-2.amazonaws.com/weddingmap",
-            "cpu": 256,
-            "memory": 256,
+            "cpu": 768,
+            "memory": 768,
             "portMappings": [],
             "essential": true,
             "environment": [],


### PR DESCRIPTION
## Related Issue

#109 

## Description

프로덕션 서버에서 발생한 에러를 해결하기 위해 애플리케이션 컨테이너를 업그레이드합니다.

- `vCPU` : 0.25 → 0.75
- `memory` : 0.25 → 0.75

## Screenshots (if appropriate):
