### PR TITLE
docs: modify wrong title in transaction api

### DIFF
--- a/src/docs/asciidoc/api/budget/transaction.adoc
+++ b/src/docs/asciidoc/api/budget/transaction.adoc
@@ -5,7 +5,7 @@
 :toclevels: 2
 :seclinks:
 
-사용자 에산표 등록, 조회, 삭제, 수정이 가능합니다.
+사용자 예산표 등록, 조회, 삭제, 수정이 가능합니다.
 이를 위해서는 ``Header``의 ``Authorization``에 사용자의 ``액세스 토큰``을 포함시켜야 합니다.
 
 === 예산표 상세 조회
@@ -28,7 +28,7 @@ operation::budget/transaction/get-transaction-list/[snippets="http-request,http-
 
 operation::budget/transaction/create-transaction/[snippets="http-request,request-fields,http-response,response-fields-data"]
 
-=== 체크리스트 아이템 수정
+=== 예산표 수정
 
 예산표 수정이 가능합니다.
 


### PR DESCRIPTION
## Related Issue
#113 
## Description
예산표 api 문서의 잘못된 타이틀을 수정하였습니다.
## Screenshots (if appropriate):
