### PR TITLE
chore: allow front-end domain cors

### DIFF
--- a/src/main/java/com/dnd/weddingmap/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/weddingmap/global/config/SecurityConfig.java
@@ -8,6 +8,8 @@ import com.dnd.weddingmap.domain.oauth.handler.OAuth2AuthenticationFailureHandle
 import com.dnd.weddingmap.domain.oauth.handler.OAuth2AuthenticationSuccessHandler;
 import com.dnd.weddingmap.domain.oauth.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -15,6 +17,9 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
 
 @Configuration
 @RequiredArgsConstructor
@@ -27,6 +32,9 @@ public class SecurityConfig {
   private final OAuth2AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler;
   private final OAuth2AuthenticationFailureHandler oauth2AuthenticationFailureHandler;
   private final CookieAuthorizationRequestRepository cookieAuthorizationRequestRepository;
+
+  @Value("${app.origin.url}")
+  private String originUrl;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -62,5 +70,19 @@ public class SecurityConfig {
     http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
     return http.build();
+  }
+
+  @Bean
+  public FilterRegistrationBean corsFilter() {
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    CorsConfiguration config = new CorsConfiguration();
+    config.setAllowCredentials(true);
+    config.addAllowedOrigin(originUrl);
+    config.addAllowedHeader("*");
+    config.addAllowedMethod("*");
+    source.registerCorsConfiguration("/**", config);
+    FilterRegistrationBean bean = new FilterRegistrationBean(new CorsFilter(source));
+    bean.setOrder(0);
+    return bean;
   }
 }

--- a/src/main/java/com/dnd/weddingmap/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/weddingmap/global/config/SecurityConfig.java
@@ -9,7 +9,6 @@ import com.dnd.weddingmap.domain.oauth.handler.OAuth2AuthenticationSuccessHandle
 import com.dnd.weddingmap.domain.oauth.service.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -18,8 +17,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
 
 @Configuration
 @RequiredArgsConstructor
@@ -38,7 +37,7 @@ public class SecurityConfig {
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    http.cors()
+    http.cors().configurationSource(corsConfigurationSource())
         .and()
         .csrf().disable()
         .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
@@ -73,7 +72,7 @@ public class SecurityConfig {
   }
 
   @Bean
-  public FilterRegistrationBean corsFilter() {
+  public CorsConfigurationSource corsConfigurationSource() {
     final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     CorsConfiguration config = new CorsConfiguration();
     config.setAllowCredentials(true);
@@ -81,8 +80,6 @@ public class SecurityConfig {
     config.addAllowedHeader("*");
     config.addAllowedMethod("*");
     source.registerCorsConfiguration("/**", config);
-    FilterRegistrationBean bean = new FilterRegistrationBean(new CorsFilter(source));
-    bean.setOrder(0);
-    return bean;
+    return source;
   }
 }

--- a/src/main/java/com/dnd/weddingmap/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/weddingmap/global/config/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig {
 
   @Bean
   public FilterRegistrationBean corsFilter() {
-    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     CorsConfiguration config = new CorsConfiguration();
     config.setAllowCredentials(true);
     config.addAllowedOrigin(originUrl);

--- a/src/main/java/com/dnd/weddingmap/global/config/WebConfig.java
+++ b/src/main/java/com/dnd/weddingmap/global/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.dnd.weddingmap.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Value("${app.origin.url}")
+  private String originUrl;
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/**")
+        .allowedOrigins(originUrl)
+        .allowedMethods("*");
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,8 @@ app:
   auth:
     token:
       refresh-cookie-key: refresh
+  origin:
+    url: ${ORIGIN_URL}
 aws:
   s3:
     access-key: ${AWS_S3_ACCESS_KEY}

--- a/src/test/java/WeddingMapApplicationTest.java
+++ b/src/test/java/WeddingMapApplicationTest.java
@@ -1,0 +1,11 @@
+import com.dnd.weddingmap.WeddingMapApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = WeddingMapApplication.class)
+class WeddingMapApplicationTest {
+
+  @Test
+  void contextLoads() {
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,5 +1,55 @@
 spring:
   jackson:
     default-property-inclusion: non_null
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: test-google-client-id
+            client-secret: test-google-client-secret
+            scope:
+              - profile
+              - email
+          kakao:
+            client-id: test-kakao-client-id
+            client-authentication-method: POST
+            client-name: Kakao
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            authorization-grant-type: authorization_code
+            scope:
+              - profile_nickname
+              - profile_image
+              - account_email
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: password
   flyway:
     enabled: false
+app:
+  auth:
+    token:
+      refresh-cookie-key: refresh
+      secret-key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+  oauth2:
+    authorized-redirect-uri: http://localhost:8080/oauth2/redirect
+  origin:
+    url: http://localhost:3000
+aws:
+  s3:
+    access-key: test-access-key
+    secret-key: test-secret-key
+    region: ap-northeast-2
+    bucket: test-bucket
+logging:
+  level:
+    org:
+      hibernate: info


### PR DESCRIPTION
## Related Issue

#115 

## Description

프론트엔드 URL간 통신을 위한 추가적인 CORS 설정입니다.

`ORIGIN_URL`이라는 환경변수에 프론트 주소를 설정하면 됩니다.

## Screenshots (if appropriate):
