### PR TITLE
feat: contract api

### DIFF
--- a/src/main/java/com/dnd/weddingmap/domain/contract/Contract.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/Contract.java
@@ -1,6 +1,7 @@
 package com.dnd.weddingmap.domain.contract;
 
 import com.dnd.weddingmap.domain.common.BaseTimeEntity;
+import com.dnd.weddingmap.domain.contract.dto.ContractDto;
 import com.dnd.weddingmap.domain.member.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -60,5 +61,20 @@ public class Contract extends BaseTimeEntity {
     this.file = file;
     this.memo = memo;
     this.member = member;
+  }
+
+  public Contract updateFile(String file) {
+    this.file = file;
+    return this;
+  }
+
+  public Contract update(ContractDto contractDto) {
+    this.title = contractDto.getTitle();
+    this.contents = contractDto.getContents();
+    this.contractDate = contractDto.getContractDate();
+    this.contractStatus  = contractDto.getContractStatus();
+    this.memo = contractDto.getMemo();
+
+    return this;
   }
 }

--- a/src/main/java/com/dnd/weddingmap/domain/contract/Contract.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/Contract.java
@@ -1,0 +1,64 @@
+package com.dnd.weddingmap.domain.contract;
+
+import com.dnd.weddingmap.domain.common.BaseTimeEntity;
+import com.dnd.weddingmap.domain.member.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+@Entity
+public class Contract extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(length = 64, nullable = false)
+  private String title;
+
+  @Column
+  private String contents;
+
+  @Column(nullable = false)
+  private LocalDate contractDate;
+
+  @Column(nullable = false)
+  @Enumerated(value = EnumType.STRING)
+  private ContractStatus contractStatus;
+
+  @Column
+  private String file;
+
+  @Column
+  private String memo;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "memberId", nullable = false)
+  private Member member;
+
+  @Builder
+  public Contract(Long id, String title, String contents, LocalDate contractDate,
+      ContractStatus contractStatus, String file, String memo, Member member) {
+    this.id = id;
+    this.title = title;
+    this.contents = contents;
+    this.contractDate = contractDate;
+    this.contractStatus = contractStatus;
+    this.file = file;
+    this.memo = memo;
+    this.member = member;
+  }
+}

--- a/src/main/java/com/dnd/weddingmap/domain/contract/ContractStatus.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/ContractStatus.java
@@ -1,0 +1,30 @@
+package com.dnd.weddingmap.domain.contract;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ContractStatus {
+
+  COMPLETE("계약 완료"),
+  IN_PROGRESS("계약중"),
+  VERBAL("구두 계약"),
+  PROVISIONAL("가계약");
+
+  private final String title;
+
+  @JsonCreator
+  public static ContractStatus findBy(String key) {
+
+    for (ContractStatus contractStatus :
+        ContractStatus.values()) {
+      if (contractStatus.name().equals(key.toUpperCase())) {
+        return contractStatus;
+      }
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/dnd/weddingmap/domain/contract/controller/ContractController.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/controller/ContractController.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -70,5 +71,16 @@ public class ContractController {
 
     return ResponseEntity.ok()
         .body(SuccessResponse.builder().data(new ContractDto(contract)).build());
+  }
+
+  @DeleteMapping("/{contract-id}")
+  public ResponseEntity<SuccessResponse> withdrawContract(
+      @AuthenticationPrincipal CustomUserDetails user,
+      @PathVariable("contract-id") Long contractId) {
+    boolean result = contractService.withdrawContract(contractId, user.getId());
+    if (!result) {
+      throw new NotFoundException("존재하지 않는 계약서입니다.");
+    }
+    return ResponseEntity.ok(SuccessResponse.builder().message("계약서 삭제 성공").build());
   }
 }

--- a/src/main/java/com/dnd/weddingmap/domain/contract/controller/ContractController.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/controller/ContractController.java
@@ -1,0 +1,54 @@
+package com.dnd.weddingmap.domain.contract.controller;
+
+import com.dnd.weddingmap.domain.contract.dto.ContractDto;
+import com.dnd.weddingmap.domain.contract.service.ContractService;
+import com.dnd.weddingmap.domain.member.Member;
+import com.dnd.weddingmap.domain.member.service.MemberService;
+import com.dnd.weddingmap.domain.oauth.CustomUserDetails;
+import com.dnd.weddingmap.global.exception.NotFoundException;
+import com.dnd.weddingmap.global.exception.RequestTimeoutException;
+import com.dnd.weddingmap.global.response.SuccessResponse;
+import com.dnd.weddingmap.global.service.S3Service;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/contract")
+public class ContractController {
+
+  private final MemberService memberService;
+  private final ContractService contractService;
+  private final S3Service s3Service;
+
+  @PostMapping
+  public ResponseEntity<SuccessResponse> createContract(
+      @AuthenticationPrincipal CustomUserDetails user,
+      @RequestPart("data") @Valid ContractDto requestDto,
+      @RequestPart("file") MultipartFile file) {
+    Member member = memberService.findMember(user.getId())
+        .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자입니다."));
+
+    String fileUrl;
+    try {
+      fileUrl = s3Service.upload(file, "contract");
+    } catch (Exception e) {
+      throw new RequestTimeoutException("계약서 파일 업로드에 실패했습니다.");
+    }
+    requestDto.setFile(fileUrl);
+    ContractDto savedContract = contractService.createContract(requestDto, member);
+
+    return ResponseEntity.status(HttpStatus.CREATED).body(
+        SuccessResponse.builder().httpStatus(HttpStatus.CREATED).message("계약서 등록 성공")
+            .data(savedContract).build());
+  }
+}

--- a/src/main/java/com/dnd/weddingmap/domain/contract/controller/ContractController.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/controller/ContractController.java
@@ -69,12 +69,7 @@ public class ContractController {
   public ResponseEntity<SuccessResponse> getContractDetail(
       @AuthenticationPrincipal CustomUserDetails user,
       @PathVariable("contract-id") Long contractId) {
-    Contract contract = contractService.findContractById(contractId)
-        .orElseThrow(() -> new NotFoundException(NOT_FOUND_CONTRACT_MESSAGE));
-
-    if (!Objects.equals(contract.getMember().getId(), user.getId())) {
-      throw new ForbiddenException("접근할 수 없는 계약서입니다.");
-    }
+    Contract contract = checkPermission(contractId, user.getId());
 
     return ResponseEntity.ok()
         .body(SuccessResponse.builder().data(new ContractDto(contract)).build());
@@ -84,8 +79,7 @@ public class ContractController {
   public ResponseEntity<SuccessResponse> withdrawContract(
       @AuthenticationPrincipal CustomUserDetails user,
       @PathVariable("contract-id") Long contractId) {
-    Contract contract = contractService.findContractById(contractId)
-        .orElseThrow(() -> new NotFoundException(NOT_FOUND_CONTRACT_MESSAGE));
+    Contract contract = checkPermission(contractId, user.getId());
 
     try {
       s3Service.delete(contract.getFile(), CONTRACT_DIRECTORY);

--- a/src/main/java/com/dnd/weddingmap/domain/contract/controller/ContractController.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/controller/ContractController.java
@@ -2,6 +2,7 @@ package com.dnd.weddingmap.domain.contract.controller;
 
 import com.dnd.weddingmap.domain.contract.Contract;
 import com.dnd.weddingmap.domain.contract.dto.ContractDto;
+import com.dnd.weddingmap.domain.contract.dto.ContractListResponseDto;
 import com.dnd.weddingmap.domain.contract.service.ContractService;
 import com.dnd.weddingmap.domain.member.Member;
 import com.dnd.weddingmap.domain.member.service.MemberService;
@@ -12,6 +13,7 @@ import com.dnd.weddingmap.global.exception.RequestTimeoutException;
 import com.dnd.weddingmap.global.response.SuccessResponse;
 import com.dnd.weddingmap.global.service.S3Service;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -82,5 +84,17 @@ public class ContractController {
       throw new NotFoundException("존재하지 않는 계약서입니다.");
     }
     return ResponseEntity.ok(SuccessResponse.builder().message("계약서 삭제 성공").build());
+  }
+
+  @GetMapping
+  public ResponseEntity<SuccessResponse> getContractList(
+      @AuthenticationPrincipal CustomUserDetails user) {
+    Member member = memberService.findMember(user.getId())
+        .orElseThrow(() -> new NotFoundException("존재하지 않는 사용자입니다."));
+
+    List<ContractListResponseDto> contractList = contractService.findContractList(member.getId());
+
+    return ResponseEntity.ok()
+        .body(SuccessResponse.builder().data(contractList).build());
   }
 }

--- a/src/main/java/com/dnd/weddingmap/domain/contract/dto/ContractDto.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/dto/ContractDto.java
@@ -1,0 +1,56 @@
+package com.dnd.weddingmap.domain.contract.dto;
+
+import com.dnd.weddingmap.domain.contract.Contract;
+import com.dnd.weddingmap.domain.contract.ContractStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Setter
+@Getter
+public class ContractDto {
+  private Long id;
+
+  @NotBlank(message = "title은 필수 요청 데이터입니다.")
+  private String title;
+
+  @NotBlank(message = "contents는 필수 요청 데이터입니다.")
+  private String contents;
+
+  @NotNull(message = "contractDate는 필수 요청 데이터입니다.")
+  private LocalDate contractDate;
+
+  @NotNull(message = "contractStatus는 필수 요청 데이터입니다.")
+  private ContractStatus contractStatus;
+
+  private String file;
+
+  private String memo;
+
+  @Builder
+  public ContractDto(Long id, String title, String contents, LocalDate contractDate,
+      ContractStatus contractStatus, String file, String memo) {
+    this.id = id;
+    this.title = title;
+    this.contents = contents;
+    this.contractDate = contractDate;
+    this.contractStatus = contractStatus;
+    this.file = file;
+    this.memo = memo;
+  }
+
+  public ContractDto(Contract contract) {
+    this.id = contract.getId();
+    this.title = contract.getTitle();
+    this.contents = contract.getContents();
+    this.contractDate = contract.getContractDate();
+    this.contractStatus = contract.getContractStatus();
+    this.file = contract.getFile();
+    this.memo = contract.getMemo();
+  }
+}

--- a/src/main/java/com/dnd/weddingmap/domain/contract/dto/ContractListResponseDto.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/dto/ContractListResponseDto.java
@@ -1,0 +1,26 @@
+package com.dnd.weddingmap.domain.contract.dto;
+
+import com.dnd.weddingmap.domain.contract.ContractStatus;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class ContractListResponseDto {
+
+  private Long id;
+  private String title;
+  private LocalDate contractDate;
+  private ContractStatus contractStatus;
+
+  @Builder
+  public ContractListResponseDto(Long id, String title, LocalDate contractDate,
+      ContractStatus contractStatus) {
+    this.id = id;
+    this.title = title;
+    this.contractDate = contractDate;
+    this.contractStatus = contractStatus;
+  }
+}

--- a/src/main/java/com/dnd/weddingmap/domain/contract/repository/ContractRepository.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/repository/ContractRepository.java
@@ -1,10 +1,12 @@
 package com.dnd.weddingmap.domain.contract.repository;
 
 import com.dnd.weddingmap.domain.contract.Contract;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ContractRepository extends JpaRepository<Contract, Long> {
 
+  List<Contract> findByMemberIdOrderByContractDate(Long id);
 }

--- a/src/main/java/com/dnd/weddingmap/domain/contract/repository/ContractRepository.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/repository/ContractRepository.java
@@ -1,0 +1,10 @@
+package com.dnd.weddingmap.domain.contract.repository;
+
+import com.dnd.weddingmap.domain.contract.Contract;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContractRepository extends JpaRepository<Contract, Long> {
+
+}

--- a/src/main/java/com/dnd/weddingmap/domain/contract/service/ContractService.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/service/ContractService.java
@@ -2,7 +2,9 @@ package com.dnd.weddingmap.domain.contract.service;
 
 import com.dnd.weddingmap.domain.contract.Contract;
 import com.dnd.weddingmap.domain.contract.dto.ContractDto;
+import com.dnd.weddingmap.domain.contract.dto.ContractListResponseDto;
 import com.dnd.weddingmap.domain.member.Member;
+import java.util.List;
 import java.util.Optional;
 
 public interface ContractService {
@@ -12,4 +14,6 @@ public interface ContractService {
   Optional<Contract> findContractById(Long id);
 
   boolean withdrawContract(Long contractId, Long memberId);
+
+  List<ContractListResponseDto> findContractList(Long memberId);
 }

--- a/src/main/java/com/dnd/weddingmap/domain/contract/service/ContractService.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/service/ContractService.java
@@ -1,0 +1,9 @@
+package com.dnd.weddingmap.domain.contract.service;
+
+import com.dnd.weddingmap.domain.contract.dto.ContractDto;
+import com.dnd.weddingmap.domain.member.Member;
+
+public interface ContractService {
+
+  ContractDto createContract(ContractDto contractDto, Member member);
+}

--- a/src/main/java/com/dnd/weddingmap/domain/contract/service/ContractService.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/service/ContractService.java
@@ -16,4 +16,8 @@ public interface ContractService {
   boolean withdrawContract(Long contractId, Long memberId);
 
   List<ContractListResponseDto> findContractList(Long memberId);
+
+  ContractDto modifyContractFile(Long contractId, String fileUrl);
+
+  ContractDto modifyContract(Long contractId, ContractDto contractDto);
 }

--- a/src/main/java/com/dnd/weddingmap/domain/contract/service/ContractService.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/service/ContractService.java
@@ -8,5 +8,8 @@ import java.util.Optional;
 public interface ContractService {
 
   ContractDto createContract(ContractDto contractDto, Member member);
+
   Optional<Contract> findContractById(Long id);
+
+  boolean withdrawContract(Long contractId, Long memberId);
 }

--- a/src/main/java/com/dnd/weddingmap/domain/contract/service/ContractService.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/service/ContractService.java
@@ -1,9 +1,12 @@
 package com.dnd.weddingmap.domain.contract.service;
 
+import com.dnd.weddingmap.domain.contract.Contract;
 import com.dnd.weddingmap.domain.contract.dto.ContractDto;
 import com.dnd.weddingmap.domain.member.Member;
+import java.util.Optional;
 
 public interface ContractService {
 
   ContractDto createContract(ContractDto contractDto, Member member);
+  Optional<Contract> findContractById(Long id);
 }

--- a/src/main/java/com/dnd/weddingmap/domain/contract/service/impl/ContractServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/service/impl/ContractServiceImpl.java
@@ -2,10 +2,13 @@ package com.dnd.weddingmap.domain.contract.service.impl;
 
 import com.dnd.weddingmap.domain.contract.Contract;
 import com.dnd.weddingmap.domain.contract.dto.ContractDto;
+import com.dnd.weddingmap.domain.contract.dto.ContractListResponseDto;
 import com.dnd.weddingmap.domain.contract.repository.ContractRepository;
 import com.dnd.weddingmap.domain.contract.service.ContractService;
 import com.dnd.weddingmap.domain.member.Member;
 import com.dnd.weddingmap.global.exception.ForbiddenException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -48,5 +51,20 @@ public class ContractServiceImpl implements ContractService {
           return true;
         })
         .orElse(false);
+  }
+
+  @Override
+  public List<ContractListResponseDto> findContractList(Long memberId) {
+    List<ContractListResponseDto> result = new ArrayList<>();
+
+    contractRepository.findByMemberIdOrderByContractDate(memberId).forEach(
+        contract -> result.add(ContractListResponseDto.builder()
+            .id(contract.getId())
+            .title(contract.getTitle())
+            .contractDate(contract.getContractDate())
+            .contractStatus(contract.getContractStatus())
+            .build()));
+
+    return result;
   }
 }

--- a/src/main/java/com/dnd/weddingmap/domain/contract/service/impl/ContractServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/service/impl/ContractServiceImpl.java
@@ -7,6 +7,8 @@ import com.dnd.weddingmap.domain.contract.repository.ContractRepository;
 import com.dnd.weddingmap.domain.contract.service.ContractService;
 import com.dnd.weddingmap.domain.member.Member;
 import com.dnd.weddingmap.global.exception.ForbiddenException;
+import com.dnd.weddingmap.global.exception.NotFoundException;
+import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -66,5 +68,23 @@ public class ContractServiceImpl implements ContractService {
             .build()));
 
     return result;
+  }
+
+  @Transactional
+  @Override
+  public ContractDto modifyContractFile(Long contractId, String fileUrl) {
+    Contract contract = contractRepository.findById(contractId).orElseThrow(
+        () -> new NotFoundException("존재하지 않는 계약서입니다.")
+    );
+    return new ContractDto(contract.updateFile(fileUrl));
+  }
+
+  @Transactional
+  @Override
+  public ContractDto modifyContract(Long contractId, ContractDto contractDto) {
+    Contract contract = contractRepository.findById(contractId).orElseThrow(
+        () -> new NotFoundException("존재하지 않는 계약서입니다.")
+    );
+    return new ContractDto(contract.update(contractDto));
   }
 }

--- a/src/main/java/com/dnd/weddingmap/domain/contract/service/impl/ContractServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/service/impl/ContractServiceImpl.java
@@ -1,0 +1,30 @@
+package com.dnd.weddingmap.domain.contract.service.impl;
+
+import com.dnd.weddingmap.domain.contract.Contract;
+import com.dnd.weddingmap.domain.contract.dto.ContractDto;
+import com.dnd.weddingmap.domain.contract.repository.ContractRepository;
+import com.dnd.weddingmap.domain.contract.service.ContractService;
+import com.dnd.weddingmap.domain.member.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ContractServiceImpl implements ContractService {
+  private final ContractRepository contractRepository;
+
+  @Override
+  public ContractDto createContract(ContractDto contractDto, Member member) {
+    Contract contract = Contract.builder()
+        .title(contractDto.getTitle())
+        .contents(contractDto.getContents())
+        .contractStatus(contractDto.getContractStatus())
+        .contractDate(contractDto.getContractDate())
+        .file(contractDto.getFile())
+        .memo(contractDto.getMemo())
+        .member(member)
+        .build();
+
+    return new ContractDto(contractRepository.save(contract));
+  }
+}

--- a/src/main/java/com/dnd/weddingmap/domain/contract/service/impl/ContractServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/service/impl/ContractServiceImpl.java
@@ -5,6 +5,8 @@ import com.dnd.weddingmap.domain.contract.dto.ContractDto;
 import com.dnd.weddingmap.domain.contract.repository.ContractRepository;
 import com.dnd.weddingmap.domain.contract.service.ContractService;
 import com.dnd.weddingmap.domain.member.Member;
+import com.dnd.weddingmap.global.exception.ForbiddenException;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 public class ContractServiceImpl implements ContractService {
+
   private final ContractRepository contractRepository;
 
   @Override
@@ -32,5 +35,18 @@ public class ContractServiceImpl implements ContractService {
   @Override
   public Optional<Contract> findContractById(Long id) {
     return contractRepository.findById(id);
+  }
+
+  @Override
+  public boolean withdrawContract(Long contractId, Long memberId) {
+    return contractRepository.findById(contractId)
+        .map(contract -> {
+          if (!Objects.equals(contract.getMember().getId(), memberId)) {
+            throw new ForbiddenException("접근할 수 없는 계약서입니다.");
+          }
+          contractRepository.delete(contract);
+          return true;
+        })
+        .orElse(false);
   }
 }

--- a/src/main/java/com/dnd/weddingmap/domain/contract/service/impl/ContractServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/service/impl/ContractServiceImpl.java
@@ -5,6 +5,7 @@ import com.dnd.weddingmap.domain.contract.dto.ContractDto;
 import com.dnd.weddingmap.domain.contract.repository.ContractRepository;
 import com.dnd.weddingmap.domain.contract.service.ContractService;
 import com.dnd.weddingmap.domain.member.Member;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -26,5 +27,10 @@ public class ContractServiceImpl implements ContractService {
         .build();
 
     return new ContractDto(contractRepository.save(contract));
+  }
+
+  @Override
+  public Optional<Contract> findContractById(Long id) {
+    return contractRepository.findById(id);
   }
 }

--- a/src/main/resources/db/migration/V202302240118__Create_contract_table.sql
+++ b/src/main/resources/db/migration/V202302240118__Create_contract_table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS `contract` (
+    `id` bigint NOT NULL AUTO_INCREMENT,
+    `created_at` datetime(6),
+    `modified_at` datetime(6),
+    `title` varchar(64) NOT NULL,
+    `contents` varchar(255) ,
+    `contract_date` date NOT NULL,
+    `contract_status` varchar(255) NOT NULL,
+    `file` varchar(512),
+    `memo` varchar(255),
+    `member_id` bigint NOT NULL,
+    PRIMARY KEY (`id`),
+    FOREIGN KEY (`member_id`) REFERENCES member (id)
+    ON DELETE CASCADE)
+    ENGINE = InnoDB
+    DEFAULT CHARACTER SET=utf8mb4;


### PR DESCRIPTION
## Related Issue
#110 
## Description
계약서 API를 구현합니다.

`/api/v1/contract/{contract-id}`

- [x] 상세 조회 **GET**
- [x] 리스트 조회 **GET**
- [x] 생성 **POST**
- [x] 계약서 내용 수정 **PUT**
- [x] 계약서 파일 수정 **POST**
- [x] 삭제 **DELETE**

## Screenshots (if appropriate):
