### PR TITLE
fix: ecs deployment fail

### DIFF
--- a/task-definition.json
+++ b/task-definition.json
@@ -61,5 +61,5 @@
     "executionRoleArn": "arn:aws:iam::339286557484:role/ecsTaskExecutionRole",
     "networkMode": "bridge",
     "volumes": [],
-    "placementConstraints": [],
+    "placementConstraints": []
 }

--- a/task-definition.json
+++ b/task-definition.json
@@ -3,8 +3,8 @@
         {
             "name": "nginx",
             "image": "339286557484.dkr.ecr.ap-northeast-2.amazonaws.com/reverse-proxy",
-            "cpu": 256,
-            "memory": 256,
+            "cpu": 204,
+            "memory": 204,
             "links": [
                 "application"
             ],


### PR DESCRIPTION
## Related Issue

#151 

## Description

배포 시 발생하는 에러를 해결합니다.

- `nginx` 컨테이너 사이즈 축소
  - 컨테이너 용량을 타이트하게 잡았더니 배포가 안되는 문제가 있었습니다.
- `task-definition.json` 내 후행 콤마 제거

## Screenshots (if appropriate):
