### PR TITLE
refactor: remove code smells

### DIFF
--- a/src/main/java/com/dnd/weddingmap/global/service/S3Service.java
+++ b/src/main/java/com/dnd/weddingmap/global/service/S3Service.java
@@ -21,9 +21,11 @@ public class S3Service {
   private final AmazonS3 amazonS3;
 
   public String upload(MultipartFile multipartFile, String directory) throws IOException {
+    String pathDelimiter = "/";
+
     String fileName = multipartFile.getOriginalFilename();
     String uuid = UUID.randomUUID().toString();
-    String saveFileName = directory + "/" + uuid + "_" + fileName;
+    String saveFileName = directory + pathDelimiter + uuid + "_" + fileName;
 
     ObjectMetadata objectMetadata = new ObjectMetadata();
     objectMetadata.setContentType(multipartFile.getContentType());

--- a/src/test/java/com/dnd/weddingmap/global/response/SuccessResponseTest.java
+++ b/src/test/java/com/dnd/weddingmap/global/response/SuccessResponseTest.java
@@ -12,31 +12,31 @@ class SuccessResponseTest {
   @DisplayName("상태코드 확인")
   void checkCode() {
     SuccessResponse successResponse = new SuccessResponse();
-    assertEquals(successResponse.getStatus(), 200);
+    assertEquals(200, successResponse.getStatus());
   }
 
   @Test
   @DisplayName("메시지 확인")
   void checkMessage() {
     SuccessResponse successResponse = SuccessResponse.builder().message("message").build();
-    assertEquals(successResponse.getStatus(), 200);
-    assertEquals(successResponse.getMessage(), "message");
+    assertEquals(200, successResponse.getStatus());
+    assertEquals("message", successResponse.getMessage());
   }
 
   @Test
   @DisplayName("데이터 확인")
   void checkData() {
     SuccessResponse successResponse = SuccessResponse.builder().data("test").build();
-    assertEquals(successResponse.getStatus(), 200);
-    assertEquals(successResponse.getData(), "test");
+    assertEquals(200, successResponse.getStatus());
+    assertEquals("test", successResponse.getData());
   }
 
   @Test
   @DisplayName("데이터 및 메시지 확인")
   void checkDataAndMessage() {
     SuccessResponse successResponse = new SuccessResponse(HttpStatus.OK, "success", "test");
-    assertEquals(successResponse.getStatus(), 200);
-    assertEquals(successResponse.getMessage(), "success");
-    assertEquals(successResponse.getData(), "test");
+    assertEquals(200, successResponse.getStatus());
+    assertEquals("success", successResponse.getMessage());
+    assertEquals("test", successResponse.getData());
   }
 }


### PR DESCRIPTION
## Related Issue

None

## Description

- 테스트 코드 상 잘못된 파라미터 순서를 변경합니다.
  - [java:S3415](https://sonarcloud.io/organizations/dnd-side-project/rules?open=java%3AS3415&rule_key=java%3AS3415)
- 하드코딩된 path-delimiter를 변수로 치환
  - [java:S1075](https://sonarcloud.io/organizations/dnd-side-project/rules?open=java%3AS1075&rule_key=java%3AS1075)
## Screenshots (if appropriate):
