### PR TITLE
refactor: add subitem option to checklist api

### DIFF
--- a/src/docs/asciidoc/api/checklist/checklist.adoc
+++ b/src/docs/asciidoc/api/checklist/checklist.adoc
@@ -8,15 +8,30 @@
 사용자 체크리스트 조회 및 온보딩 체크리스트 사전 등록이 가능합니다.
 이를 위해서는 ``Header``의 ``Authorization``에 사용자의 ``액세스 토큰``을 포함시켜야 합니다.
 
-=== 체크리스트 조회
+=== 체크리스트 조회 (서브 아이템 포함)
 
 사용자의 ``전체 체크리스트``를 조회할 수 있습니다.
+
+요청 시 ``query`` 값은 ``true``로 설정합니다.
 
 사용자가 등록한 체크리스트 아이템과 체크리스트 서브 아이템 목록 전체를 조회할 수 있습니다.
 
 응답 데이터는 ``체크리스트 아이템 일정 날짜 (checkDate)`` 에 맞추어 오름차순으로 정렬된 데이터이며, 일정 날짜가 입력되지 않은 데이터가 제일 앞쪽에 위치합니다.
 
-operation::checklist/checklist/[snippets="http-request,http-response,response-fields-data"]
+operation::checklist/checklist/withSubitem/[snippets="http-request,query-parameters,http-response,response-fields-data"]
+
+=== 체크리스트 조회 (서브 아이템 미포함)
+
+사용자의 ``전체 체크리스트``를 조회할 수 있습니다.
+(서브 아이템 미포함)
+
+요청 시 ``query`` 값은 ``false``로 설정합니다.
+
+사용자가 등록한 체크리스트 아이템 목록 전체를 조회할 수 있습니다.
+
+응답 데이터는 ``체크리스트 아이템 일정 날짜 (checkDate)`` 에 맞추어 오름차순으로 정렬된 데이터이며, 일정 날짜가 입력되지 않은 데이터가 제일 앞쪽에 위치합니다.
+
+operation::checklist/checklist/[snippets="http-request,query-parameters,http-response,response-fields-data"]
 
 === 온보딩 체크리스트 사전 등록
 

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistController.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -32,12 +33,17 @@ public class ChecklistController {
 
   @GetMapping
   public ResponseEntity<SuccessResponse> getChecklist(
-      @AuthenticationPrincipal CustomUserDetails user) {
+      @AuthenticationPrincipal CustomUserDetails user, @RequestParam boolean subitem) {
     Member member = memberService.findMember(user.getId())
         .orElseThrow(
             () -> new NotFoundException(MessageUtil.getMessage("member.notFound.exception")));
 
-    List<ChecklistItemApiDto> result = checklistService.findChecklist(member.getId());
+    if (subitem) {
+      List<ChecklistItemApiDto> result = checklistService.findChecklist(member.getId());
+      return ResponseEntity.ok().body(SuccessResponse.builder().data(result).build());
+    }
+
+    List<ChecklistItemDto> result = checklistService.findChecklistItem(member.getId());
     return ResponseEntity.ok().body(SuccessResponse.builder().data(result).build());
   }
 

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistController.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistController.java
@@ -39,11 +39,11 @@ public class ChecklistController {
             () -> new NotFoundException(MessageUtil.getMessage("member.notFound.exception")));
 
     if (subitem) {
-      List<ChecklistItemApiDto> result = checklistService.findChecklist(member.getId());
+      List<ChecklistItemApiDto> result = checklistService.findChecklistWithSubitem(member.getId());
       return ResponseEntity.ok().body(SuccessResponse.builder().data(result).build());
     }
 
-    List<ChecklistItemDto> result = checklistService.findChecklistItem(member.getId());
+    List<ChecklistItemDto> result = checklistService.findChecklistWithoutSubitem(member.getId());
     return ResponseEntity.ok().body(SuccessResponse.builder().data(result).build());
   }
 

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistController.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistController.java
@@ -43,7 +43,7 @@ public class ChecklistController {
       return ResponseEntity.ok().body(SuccessResponse.builder().data(result).build());
     }
 
-    List<ChecklistItemDto> result = checklistService.findChecklistWithoutSubitem(member.getId());
+    List<ChecklistItemDto> result = checklistService.findChecklist(member.getId());
     return ResponseEntity.ok().body(SuccessResponse.builder().data(result).build());
   }
 

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/service/ChecklistService.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/service/ChecklistService.java
@@ -8,9 +8,9 @@ import java.util.List;
 
 public interface ChecklistService {
 
-  List<ChecklistItemApiDto> findChecklist(Long memberId);
+  List<ChecklistItemApiDto> findChecklistWithSubitem(Long memberId);
 
-  List<ChecklistItemDto> findChecklistItem(Long memberId);
+  List<ChecklistItemDto> findChecklistWithoutSubitem(Long memberId);
 
   List<ChecklistItemDto> savePreChecklistItemList(
       Member member, PreChecklistItemListDto preChecklistItemListDto);

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/service/ChecklistService.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/service/ChecklistService.java
@@ -10,6 +10,8 @@ public interface ChecklistService {
 
   List<ChecklistItemApiDto> findChecklist(Long memberId);
 
+  List<ChecklistItemDto> findChecklistItem(Long memberId);
+
   List<ChecklistItemDto> savePreChecklistItemList(
       Member member, PreChecklistItemListDto preChecklistItemListDto);
 }

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/service/ChecklistService.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/service/ChecklistService.java
@@ -10,7 +10,7 @@ public interface ChecklistService {
 
   List<ChecklistItemApiDto> findChecklistWithSubitem(Long memberId);
 
-  List<ChecklistItemDto> findChecklistWithoutSubitem(Long memberId);
+  List<ChecklistItemDto> findChecklist(Long memberId);
 
   List<ChecklistItemDto> savePreChecklistItemList(
       Member member, PreChecklistItemListDto preChecklistItemListDto);

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/service/impl/ChecklistServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/service/impl/ChecklistServiceImpl.java
@@ -25,7 +25,7 @@ public class ChecklistServiceImpl implements ChecklistService {
 
   @Override
   @Transactional(readOnly = true)
-  public List<ChecklistItemApiDto> findChecklist(Long memberId) {
+  public List<ChecklistItemApiDto> findChecklistWithSubitem(Long memberId) {
     List<ChecklistItem> checklistItemList = checklistItemRepository.findByMemberIdOrderByCheckDate(
         memberId);
     List<ChecklistItemApiDto> result = new ArrayList<>();
@@ -36,7 +36,7 @@ public class ChecklistServiceImpl implements ChecklistService {
 
   @Override
   @Transactional(readOnly = true)
-  public List<ChecklistItemDto> findChecklistItem(Long memberId) {
+  public List<ChecklistItemDto> findChecklistWithoutSubitem(Long memberId) {
     List<ChecklistItem> checklistItemList = checklistItemRepository.findByMemberIdOrderByCheckDate(
         memberId);
     List<ChecklistItemDto> result = new ArrayList<>();

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/service/impl/ChecklistServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/service/impl/ChecklistServiceImpl.java
@@ -36,7 +36,7 @@ public class ChecklistServiceImpl implements ChecklistService {
 
   @Override
   @Transactional(readOnly = true)
-  public List<ChecklistItemDto> findChecklistWithoutSubitem(Long memberId) {
+  public List<ChecklistItemDto> findChecklist(Long memberId) {
     List<ChecklistItem> checklistItemList = checklistItemRepository.findByMemberIdOrderByCheckDate(
         memberId);
     List<ChecklistItemDto> result = new ArrayList<>();

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/service/impl/ChecklistServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/service/impl/ChecklistServiceImpl.java
@@ -35,6 +35,17 @@ public class ChecklistServiceImpl implements ChecklistService {
   }
 
   @Override
+  @Transactional(readOnly = true)
+  public List<ChecklistItemDto> findChecklistItem(Long memberId) {
+    List<ChecklistItem> checklistItemList = checklistItemRepository.findByMemberIdOrderByCheckDate(
+        memberId);
+    List<ChecklistItemDto> result = new ArrayList<>();
+    checklistItemList.forEach(item -> result.add(new ChecklistItemDto(item)));
+
+    return result;
+  }
+
+  @Override
   @Transactional(rollbackFor = Exception.class)
   public List<ChecklistItemDto> savePreChecklistItemList(Member member,
       PreChecklistItemListDto preChecklistItemListDto) {

--- a/src/test/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistControllerTest.java
+++ b/src/test/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistControllerTest.java
@@ -112,7 +112,8 @@ class ChecklistControllerTest extends AbstractRestDocsTests {
 
     // given
     given(memberService.findMember(anyLong())).willReturn(Optional.ofNullable(member));
-    given(checklistService.findChecklist(anyLong())).willReturn(List.of(checklistItemApiDto1));
+    given(checklistService.findChecklistWithSubitem(anyLong())).willReturn(
+        List.of(checklistItemApiDto1));
 
     // when
     ResultActions result = mockMvc.perform(get(url)
@@ -165,7 +166,8 @@ class ChecklistControllerTest extends AbstractRestDocsTests {
 
     // given
     given(memberService.findMember(anyLong())).willReturn(Optional.ofNullable(member));
-    given(checklistService.findChecklistItem(anyLong())).willReturn(List.of(checklistItemDto));
+    given(checklistService.findChecklistWithoutSubitem(anyLong())).willReturn(
+        List.of(checklistItemDto));
 
     // when
     ResultActions result = mockMvc.perform(get(url)

--- a/src/test/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistControllerTest.java
+++ b/src/test/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistControllerTest.java
@@ -166,7 +166,7 @@ class ChecklistControllerTest extends AbstractRestDocsTests {
 
     // given
     given(memberService.findMember(anyLong())).willReturn(Optional.ofNullable(member));
-    given(checklistService.findChecklistWithoutSubitem(anyLong())).willReturn(
+    given(checklistService.findChecklist(anyLong())).willReturn(
         List.of(checklistItemDto));
 
     // when

--- a/src/test/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistControllerTest.java
+++ b/src/test/java/com/dnd/weddingmap/domain/checklist/controller/ChecklistControllerTest.java
@@ -10,6 +10,8 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.beneathP
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.dnd.weddingmap.docs.springrestdocs.AbstractRestDocsTests;
@@ -104,9 +106,9 @@ class ChecklistControllerTest extends AbstractRestDocsTests {
 
   @Test
   @WithMockOAuth2User
-  @DisplayName("사용자 체크리스트 조회")
+  @DisplayName("서브 아이템 포함 사용자 체크리스트 조회 ")
   void getChecklist() throws Exception {
-    String url = "/api/v1/checklist";
+    String url = "/api/v1/checklist?subitem=true";
 
     // given
     given(memberService.findMember(anyLong())).willReturn(Optional.ofNullable(member));
@@ -119,7 +121,10 @@ class ChecklistControllerTest extends AbstractRestDocsTests {
     // then
     result.andExpect(status().isOk())
         .andDo(
-            document("checklist/checklist",
+            document("checklist/checklist/withSubitem",
+                queryParameters(
+                    parameterWithName("subitem").description("서브아이템 조회 여부")
+                ),
                 responseFields(
                     beneathPath("data").withSubsectionId("data"),
                     fieldWithPath("checklistItem.id").description("체크리스트 아이템 아이디").type(
@@ -148,6 +153,50 @@ class ChecklistControllerTest extends AbstractRestDocsTests {
                     fieldWithPath("checklistSubItems[].isChecked").description(
                         "체크리스트 서브 아이템 체크 여부").type(
                         JsonFieldType.BOOLEAN)
+                )
+            ));
+  }
+
+  @Test
+  @WithMockOAuth2User
+  @DisplayName("서브 아이템 미포함 사용자 체크리스트 조회 ")
+  void getChecklistWithoutSubitem() throws Exception {
+    String url = "/api/v1/checklist?subitem=false";
+
+    // given
+    given(memberService.findMember(anyLong())).willReturn(Optional.ofNullable(member));
+    given(checklistService.findChecklistItem(anyLong())).willReturn(List.of(checklistItemDto));
+
+    // when
+    ResultActions result = mockMvc.perform(get(url)
+        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_PREFIX + "ACCESS_TOKEN"));
+
+    // then
+    result.andExpect(status().isOk())
+        .andDo(
+            document("checklist/checklist",
+                queryParameters(
+                    parameterWithName("subitem").description("서브아이템 조회 여부")
+                ),
+                responseFields(
+                    beneathPath("data").withSubsectionId("data"),
+                    fieldWithPath("id").description("체크리스트 아이템 아이디").type(
+                        JsonFieldType.NUMBER),
+                    fieldWithPath("title").description("체크리스트 아이템 제목").type(
+                        JsonFieldType.STRING),
+                    fieldWithPath("checkDate").description(
+                        "체크리스트 아이템 일정 날짜").type(
+                        JsonFieldType.STRING),
+                    fieldWithPath("startTime").description(
+                        "체크리스트 아이템 일정 시작 시간").type(
+                        JsonFieldType.STRING),
+                    fieldWithPath("endTime").description(
+                        "체크리스트 아이템 일정 종료 시간").type(
+                        JsonFieldType.STRING),
+                    fieldWithPath("place").description("체크리스트 아이템 일정 장소").type(
+                        JsonFieldType.STRING),
+                    fieldWithPath("memo").description("체크리스트 아이템 메모").type(
+                        JsonFieldType.STRING)
                 )
             ));
   }


### PR DESCRIPTION
## Related Issue
#163 
## Description
체크리스트 조회 시 서브 아이템 조회 유무를 `query`를 사용하여 선택할 수 있도록 수정하였습니다.
## Screenshots (if appropriate):
