### PR TITLE
fix(jwt): JWT String argument cannot be null or empty

### DIFF
--- a/src/main/java/com/dnd/weddingmap/domain/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dnd/weddingmap/domain/jwt/JwtAuthenticationFilter.java
@@ -26,7 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     String accessToken = HeaderUtil.getAccessToken(request);
 
-    if (Boolean.TRUE.equals(tokenProvider.validateToken(accessToken))) {
+    if (accessToken != null && Boolean.TRUE.equals(tokenProvider.validateToken(accessToken))) {
       Authentication authentication = tokenProvider.getAuthentication(accessToken);
       SecurityContextHolder.getContext().setAuthentication(authentication);
       log.debug("save: " + authentication.getName() + "credentials");


### PR DESCRIPTION
## Related Issue

#74 

## Description

`JWT Authentication Filter`에서 `Access Token`이 `Null`인 경우를 처리하지 않아 발생한 에러를 해결하였습니다.

## Screenshots (if appropriate):
