### PR TITLE
refactor: remove rollbackfor option of transaction annotation

### DIFF
--- a/src/main/java/com/dnd/weddingmap/domain/checklist/checklistitem/service/impl/ChecklistItemServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/checklistitem/service/impl/ChecklistItemServiceImpl.java
@@ -28,7 +28,7 @@ public class ChecklistItemServiceImpl implements ChecklistItemService {
   private final ChecklistSubItemRepository checklistSubItemRepository;
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public ChecklistItemApiDto createChecklistItem(ChecklistItemApiDto dto, Member member) {
     ChecklistItem savedChecklistItem = saveChecklistItem(dto.getChecklistItem(), member);
 
@@ -49,12 +49,12 @@ public class ChecklistItemServiceImpl implements ChecklistItemService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public ChecklistItem saveChecklistItem(ChecklistItemDto checklistItemDto, Member member) {
     return checklistItemRepository.save(checklistItemDto.toEntity(member));
   }
 
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   @Override
   public List<ChecklistSubItem> saveChecklistSubItemList(
       List<ChecklistSubItemDto> checklistSubItemDtoList,
@@ -65,7 +65,7 @@ public class ChecklistItemServiceImpl implements ChecklistItemService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public ChecklistItemApiDto modifyChecklistItem(Long checklistItemId,
       ChecklistItemApiDto dto) {
     ChecklistItem modifiedChecklistItem = updateChecklistItem(
@@ -86,7 +86,7 @@ public class ChecklistItemServiceImpl implements ChecklistItemService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public ChecklistItem updateChecklistItem(Long checklistItemId,
       ChecklistItemDto checklistItemDto) {
     Optional<ChecklistItem> checklistItem = checklistItemRepository.findById(
@@ -99,14 +99,14 @@ public class ChecklistItemServiceImpl implements ChecklistItemService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public List<ChecklistSubItem> updateChecklistSubItemList(
       List<ChecklistSubItemDto> checklistSubItemDtoList) {
     return checklistSubItemDtoList.stream().map(this::updateChecklistSubItem).toList();
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public ChecklistSubItem updateChecklistSubItem(ChecklistSubItemDto checklistSubItemDto) {
     Optional<ChecklistSubItem> checklistSubItem = checklistSubItemRepository.findById(
         checklistSubItemDto.getId());
@@ -119,7 +119,7 @@ public class ChecklistItemServiceImpl implements ChecklistItemService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public boolean withdrawChecklistItem(Long id) {
     return checklistItemRepository.findById(id)
         .map(checklistItem -> {

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/checklistsubitem/service/impl/ChecklistSubItemServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/checklistsubitem/service/impl/ChecklistSubItemServiceImpl.java
@@ -29,14 +29,14 @@ public class ChecklistSubItemServiceImpl implements ChecklistSubItemService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public ChecklistSubItem saveChecklistSubItem(ChecklistSubItemDto checklistSubItemDto,
       ChecklistItem checklistItem) {
     return checklistSubItemRepository.save(checklistSubItemDto.toEntity(checklistItem));
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public boolean withdrawChecklistSubItem(Long subItemId, Long itemId) {
     ChecklistSubItem checklistSubItem = checklistSubItemRepository.findById(subItemId)
         .orElseThrow(() -> new NotFoundException(
@@ -50,7 +50,7 @@ public class ChecklistSubItemServiceImpl implements ChecklistSubItemService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public ChecklistSubItem modifyChecklistSubItem(Long subItemId, Long itemId,
       ChecklistSubItemStateDto checklistSubItemStateDto) {
     ChecklistSubItem checklistSubItem = checklistSubItemRepository.findById(subItemId)

--- a/src/main/java/com/dnd/weddingmap/domain/checklist/service/impl/ChecklistServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/checklist/service/impl/ChecklistServiceImpl.java
@@ -46,7 +46,7 @@ public class ChecklistServiceImpl implements ChecklistService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public List<ChecklistItemDto> savePreChecklistItemList(Member member,
       PreChecklistItemListDto preChecklistItemListDto) {
     return preChecklistItemListDto.getPreChecklistItems().stream()

--- a/src/main/java/com/dnd/weddingmap/domain/contract/service/impl/ContractServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/contract/service/impl/ContractServiceImpl.java
@@ -22,7 +22,7 @@ public class ContractServiceImpl implements ContractService {
   private final ContractRepository contractRepository;
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public ContractDto createContract(ContractDto contractDto, Member member) {
     Contract contract = Contract.builder()
         .title(contractDto.getTitle())
@@ -44,7 +44,7 @@ public class ContractServiceImpl implements ContractService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public boolean withdrawContract(Long contractId) {
     return contractRepository.findById(contractId)
         .map(contract -> {
@@ -71,7 +71,7 @@ public class ContractServiceImpl implements ContractService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public ContractDto modifyContractFile(Long contractId, String fileUrl) {
     Contract contract = contractRepository.findById(contractId).orElseThrow(
         () -> new NotFoundException(MessageUtil.getMessage("contract.notFound.exception"))
@@ -80,7 +80,7 @@ public class ContractServiceImpl implements ContractService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public ContractDto modifyContract(Long contractId, ContractDto contractDto) {
     Contract contract = contractRepository.findById(contractId).orElseThrow(
         () -> new NotFoundException(MessageUtil.getMessage("contract.notFound.exception"))

--- a/src/main/java/com/dnd/weddingmap/domain/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/member/service/impl/MemberServiceImpl.java
@@ -17,7 +17,7 @@ public class MemberServiceImpl implements MemberService {
   private final MemberRepository memberRepository;
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public void modifyName(Long id, NameDto nameDto) {
     Optional<Member> member = memberRepository.findById(id);
 
@@ -34,7 +34,7 @@ public class MemberServiceImpl implements MemberService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public void postGender(Long id, Gender gender) {
     Optional<Member> member = memberRepository.findById(id);
 
@@ -51,7 +51,7 @@ public class MemberServiceImpl implements MemberService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public void putProfileImage(Long id, String url) {
     Optional<Member> member = memberRepository.findById(id);
 
@@ -62,7 +62,7 @@ public class MemberServiceImpl implements MemberService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public boolean withdraw(Long id) {
     return memberRepository.findById(id)
         .map(member -> {

--- a/src/main/java/com/dnd/weddingmap/domain/transaction/service/impl/TransactionServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/transaction/service/impl/TransactionServiceImpl.java
@@ -24,7 +24,7 @@ public class TransactionServiceImpl implements TransactionService {
   private final TransactionRepository transactionRepository;
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public TransactionDto createTransaction(TransactionDto dto, Member member) {
     Transaction savedTransaction = transactionRepository.save(dto.toEntity(member));
     return new TransactionDto(savedTransaction);
@@ -46,7 +46,7 @@ public class TransactionServiceImpl implements TransactionService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public TransactionDto modifyTransaction(Long id, TransactionDto transactionDto) {
     Transaction transaction = transactionRepository.findById(id).orElseThrow(
         () -> new BadRequestException(
@@ -56,7 +56,7 @@ public class TransactionServiceImpl implements TransactionService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public boolean withdrawTransaction(Long id) {
     return transactionRepository.findById(id)
         .map(transaction -> {

--- a/src/main/java/com/dnd/weddingmap/domain/wedding/service/impl/WeddingServiceImpl.java
+++ b/src/main/java/com/dnd/weddingmap/domain/wedding/service/impl/WeddingServiceImpl.java
@@ -20,7 +20,7 @@ public class WeddingServiceImpl implements WeddingService {
   private final MemberRepository memberRepository;
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public Long registerWedding(Long memberId, WeddingDayDto weddingDayDto) {
 
     Member member = memberRepository.findById(memberId)
@@ -41,7 +41,7 @@ public class WeddingServiceImpl implements WeddingService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public void modifyWeddingDay(Long memberId, WeddingDayDto weddingDayDto) {
 
     Member member = memberRepository.findById(memberId)
@@ -79,7 +79,7 @@ public class WeddingServiceImpl implements WeddingService {
   }
 
   @Override
-  @Transactional(rollbackFor = Exception.class)
+  @Transactional
   public void modifyBudget(Long memberId, BudgetDto budgetDto) {
 
     Member member = memberRepository.findById(memberId)


### PR DESCRIPTION
## Related Issue

#168 

## Description

불필요한 rollbackFor 옵션을 제거하였습니다.

## Screenshots (if appropriate):
